### PR TITLE
Promote `Felt`'s value to be public

### DIFF
--- a/Sources/Starknet/Data/Felt.swift
+++ b/Sources/Starknet/Data/Felt.swift
@@ -2,7 +2,7 @@ import Foundation
 import BigInt
 
 public struct Felt {
-    internal let value: BigUInt
+    public let value: BigUInt
     
     public static let prime = BigUInt(2).power(251) + 17 * BigUInt(2).power(192) + 1
     


### PR DESCRIPTION
The `value` can be useful for consumers when making contract calls to access the value, e.g. pulling a balance.