### PR TITLE
Make `keccak` public to allow sign arbitrary messages

### DIFF
--- a/Sources/Starknet/Crypto/Keccak.swift
+++ b/Sources/Starknet/Crypto/Keccak.swift
@@ -4,7 +4,7 @@ import BigInt
 
 private let mask250 = BigUInt(2).power(250) - BigUInt(1)
 
-internal func keccak(on bytes: [UInt8]) -> Felt {
+public func keccak(on bytes: [UInt8]) -> Felt {
     let hashed = bytes.sha3(.keccak256)
     let data = Data(hashed)
     let masked = BigUInt(data) & mask250

--- a/Sources/Starknet/Crypto/Keccak.swift
+++ b/Sources/Starknet/Crypto/Keccak.swift
@@ -4,7 +4,7 @@ import BigInt
 
 private let mask250 = BigUInt(2).power(250) - BigUInt(1)
 
-public func keccak(on bytes: [UInt8]) -> Felt {
+public func starknetKeccak(on bytes: [UInt8]) -> Felt {
     let hashed = bytes.sha3(.keccak256)
     let data = Data(hashed)
     let masked = BigUInt(data) & mask250

--- a/Sources/Starknet/Data/Selector.swift
+++ b/Sources/Starknet/Data/Selector.swift
@@ -11,5 +11,5 @@ public func starknetSelector(from name: String) -> Felt {
         return Felt.zero
     }
     
-    return keccak(on: name.bytes)
+    return starknetKeccak(on: name.bytes)
 }


### PR DESCRIPTION
We need public access to compute the hash of a message to be signed.