### PR TITLE
Fixed memory problem with crypto-cpp buffer.

### DIFF
--- a/Sources/CryptoToolkit/CryptoRs.swift
+++ b/Sources/CryptoToolkit/CryptoRs.swift
@@ -3,12 +3,12 @@ import CFrameworkWrapper
 
 public class CryptoRs {
     public static func getRfc6979Nonce(hash: Data, privateKey: Data, seed: Data) throws -> Data {
-        let (data, returnCode) = try runWithBufferOf(size: bufferByteSize) { buffer in
+        let data = runWithBuffer(resultSize: standardResultSize, expectedReturnCode: 0) { buffer in
             return generate_k(hash.toNative(), privateKey.toNative(), seed.toNative(), buffer)
         }
-            
-        guard returnCode == 0 else {
-            throw CryptoToolkitError.cryptoRsError
+        
+        guard let data = data else {
+            throw CryptoToolkitError.nativeError
         }
         
         return data

--- a/Sources/CryptoToolkit/CryptoToolkitError.swift
+++ b/Sources/CryptoToolkit/CryptoToolkitError.swift
@@ -1,6 +1,5 @@
 import Foundation
 
 public enum CryptoToolkitError: Error {
-    case cryptoCppError
-    case cryptoRsError
+    case nativeError
 }

--- a/Sources/CryptoToolkit/Utils.swift
+++ b/Sources/CryptoToolkit/Utils.swift
@@ -1,21 +1,27 @@
 import Foundation
 
-internal func runWithBufferOf(size bufferSize: Int, body: (_ buffer: UnsafeMutablePointer<CChar>) -> Int32) throws -> (data: Data, returnCode: Int32) {
-    let buffer = UnsafeMutablePointer<CChar>.allocate(capacity: bufferSize)
+internal func runWithBuffer(resultSize: Int, expectedReturnCode: Int, body: (_ buffer: UnsafeMutablePointer<CChar>) -> Int32) -> Data? {
+    let buffer = UnsafeMutablePointer<CChar>.allocate(capacity: outBufferSize)
     defer {
         buffer.deallocate()
     }
     
     let returnCode = body(buffer)
     
+    guard returnCode == expectedReturnCode else {
+        return nil
+    }
+    
     var output = Data()
-    return buffer.withMemoryRebound(to: UInt8.self, capacity: bufferSize) { (pointer: UnsafeMutablePointer<UInt8>) in
-        output.append(pointer, count: bufferSize)
-        return (output, returnCode)
+    return buffer.withMemoryRebound(to: UInt8.self, capacity: resultSize) { (pointer: UnsafeMutablePointer<UInt8>) in
+        output.append(pointer, count: resultSize)
+        return output
     }
 }
 
-internal let bufferByteSize = 32
+private let outBufferSize = 1024
+internal let standardResultSize = 32
+
 
 internal extension Data {
     func paddingLeft(toLength length: Int) -> Data {

--- a/Sources/Starknet/Crypto/StarknetCurve.swift
+++ b/Sources/Starknet/Crypto/StarknetCurve.swift
@@ -4,6 +4,7 @@ import BigInt
 
 public enum StarknetCurveError: Error {
     case deserializationError
+    case invalidArgumentError
     case verifyError
     case unknownError
 }
@@ -15,15 +16,15 @@ public class StarknetCurve {
     /// Compute pedersen hash on input values.
     ///
     /// - Returns: Pedersen hash of the two values as Felt.
-    public class func pedersen(first: Felt, second: Felt) throws -> Felt {
-        let result = try CryptoCpp.pedersen(first: first.serialize(), second: second.serialize())
+    public class func pedersen(first: Felt, second: Felt) -> Felt {
+        let result = CryptoCpp.pedersen(first: first.serialize(), second: second.serialize())
         
-        return try result.toFelt()
+        return Felt(result)!
     }
     
-    private class func pedersen(_ values: [Felt]) throws -> Felt {
-        return try values.reduce(Felt(0)) { (previous, current) in
-            return try pedersen(first: previous, second: current)
+    private class func pedersen(_ values: [Felt]) -> Felt {
+        return values.reduce(Felt(0)) { (previous, current) in
+            return pedersen(first: previous, second: current)
         }
     }
     
@@ -34,8 +35,8 @@ public class StarknetCurve {
     /// - Parameters:
     ///     - elements: array of felt values, used as input to Pedersen hash.
     /// - Returns: Pedersen hash on elements array and its length.
-    public class func pedersenOn(elements: [Felt]) throws -> Felt {
-        return try pedersen(first: pedersen(elements), second: Felt(BigUInt(elements.count))!)
+    public class func pedersenOn(elements: [Felt]) -> Felt {
+        return pedersen(first: pedersen(elements), second: Felt(BigUInt(elements.count))!)
     }
     
     /// Compute pedersen hash on an array of input values passed as a variadic expression.
@@ -45,9 +46,9 @@ public class StarknetCurve {
     /// - Parameters:
     ///     - elements: series of felt values, used as input to Pedersen hash.
     /// - Returns: Pedersen hash on elements array and its length.
-    public class func pedersenOn(elements: Felt...) throws -> Felt {
+    public class func pedersenOn(elements: Felt...) -> Felt {
         let elementsArray = Array(elements)
-        return try pedersenOn(elements: elementsArray)
+        return pedersenOn(elements: elementsArray)
     }
     
     /// Compute Starknet public key for given private key.
@@ -56,6 +57,10 @@ public class StarknetCurve {
     ///     - privateKey: starknet private key as Felt.
     /// - Returns: Public key as Felt.
     public class func getPublicKey(privateKey: Felt) throws -> Felt {
+        guard privateKey != 0 else {
+            throw StarknetCurveError.invalidArgumentError
+        }
+        
         let publicKey = try CryptoCpp.getPublicKey(privateKey: privateKey.serialize())
         
         return try publicKey.toFelt()
@@ -73,7 +78,7 @@ public class StarknetCurve {
             throw StarknetCurveError.verifyError
         }
         
-        return try CryptoCpp.verify(publicKey: publicKey.serialize(), hash: hash.serialize(), r: r.serialize(), s: w.serialize())
+        return CryptoCpp.verify(publicKey: publicKey.serialize(), hash: hash.serialize(), r: r.serialize(), s: w.serialize())
     }
     
     /// Sign hash with StarknetPrivate key and given k value.

--- a/Tests/StarknetTests/Crypto/StarknetCurveTests.swift
+++ b/Tests/StarknetTests/Crypto/StarknetCurveTests.swift
@@ -105,11 +105,7 @@ final class StarknetCurveTests: XCTestCase {
         
         XCTAssertEqual(result, publicKey)
         
-        XCTAssertThrowsError(try StarknetCurve.getPublicKey(privateKey: Felt.zero)) { error in
-            print(error)
-        }
-        
-        print("dupa")
+        XCTAssertThrowsError(try StarknetCurve.getPublicKey(privateKey: Felt.zero))
     }
     
     func testVerify() throws {

--- a/Tests/StarknetTests/Crypto/StarknetCurveTests.swift
+++ b/Tests/StarknetTests/Crypto/StarknetCurveTests.swift
@@ -72,8 +72,8 @@ final class StarknetCurveTests: XCTestCase {
             ),
         ]
         
-        try cases.forEach {
-            let result = try StarknetCurve.pedersen(first: $0, second: $1)
+        cases.forEach {
+            let result = StarknetCurve.pedersen(first: $0, second: $1)
             print("\($0), \($1), \(result)")
             
             XCTAssertEqual(result, $2)
@@ -91,8 +91,8 @@ final class StarknetCurveTests: XCTestCase {
             )
         ]
         
-        try cases.forEach {
-            let result = try StarknetCurve.pedersenOn(elements: $0)
+        cases.forEach {
+            let result = StarknetCurve.pedersenOn(elements: $0)
             
             let expectedFelt = $1
             
@@ -104,6 +104,12 @@ final class StarknetCurveTests: XCTestCase {
         let result = try StarknetCurve.getPublicKey(privateKey: privateKey)
         
         XCTAssertEqual(result, publicKey)
+        
+        XCTAssertThrowsError(try StarknetCurve.getPublicKey(privateKey: Felt.zero)) { error in
+            print(error)
+        }
+        
+        print("dupa")
     }
     
     func testVerify() throws {


### PR DESCRIPTION
When a function from crypto-cpp executes successfully, it only uses as much buffer as it requires. However, in case of an error, it uses 1024 byte size buffer. This wasn't handled, and caused bad access errorrs.

Also made pedersen hush function non-throwable.