### PR TITLE
Updated ExectutionParams visibility

### DIFF
--- a/Sources/Starknet/Data/Execution.swift
+++ b/Sources/Starknet/Data/Execution.swift
@@ -24,6 +24,11 @@ public struct StarknetCall: Codable, Equatable {
 public struct StarknetExecutionParams {
     public let nonce: Felt
     public let maxFee: Felt
+    
+    public init(nonce: Felt, maxFee: Felt) {
+        self.nonce = nonce
+        self.maxFee = maxFee
+    }
 }
 
 func callsToExecuteCalldata(calls: [StarknetCall]) -> [Felt] {


### PR DESCRIPTION
Made initializer of ExecutionParams public.

Also, after the problem with transaction version for estimateFee is solved, we might consider if it's worth using ExecutionParams struct instead of just nonce and maxFee.