### PR TITLE
Replace static fields with single constants field in DevnetClient

### DIFF
--- a/Tests/StarknetTests/Accounts/AccountTest.swift
+++ b/Tests/StarknetTests/Accounts/AccountTest.swift
@@ -20,8 +20,8 @@ final class AccountTests: XCTestCase {
         }
 
         provider = StarknetProvider(starknetChainId: .testnet, url: Self.devnetClient.rpcUrl)!
-        accountContractClassHash = DevnetClient.accountContractClassHash
-        let accountDetails = DevnetClient.predeployedAccount1
+        accountContractClassHash = AccountTests.devnetClient.constants.accountContractClassHash
+        let accountDetails = AccountTests.devnetClient.constants.predeployedAccount1
         signer = StarkCurveSigner(privateKey: accountDetails.privateKey)!
         account = StarknetAccount(address: accountDetails.address, signer: signer, provider: provider, cairoVersion: .zero)
     }
@@ -44,7 +44,7 @@ final class AccountTests: XCTestCase {
     }
 
     func testExecute() async throws {
-        let recipientAddress = DevnetClient.predeployedAccount2.address
+        let recipientAddress = AccountTests.devnetClient.constants.predeployedAccount2.address
 
         let calldata: [Felt] = [
             recipientAddress,
@@ -60,7 +60,7 @@ final class AccountTests: XCTestCase {
     }
 
     func testExecuteCustomParams() async throws {
-        let recipientAddress = DevnetClient.predeployedAccount2.address
+        let recipientAddress = AccountTests.devnetClient.constants.predeployedAccount2.address
 
         let calldata: [Felt] = [
             recipientAddress,
@@ -82,7 +82,7 @@ final class AccountTests: XCTestCase {
     }
 
     func testExecuteMultipleCalls() async throws {
-        let recipientAddress = DevnetClient.predeployedAccount2.address
+        let recipientAddress = AccountTests.devnetClient.constants.predeployedAccount2.address
 
         let calldata1: [Felt] = [
             recipientAddress,
@@ -96,8 +96,8 @@ final class AccountTests: XCTestCase {
             0,
         ]
 
-        let call1 = StarknetCall(contractAddress: DevnetClient.erc20ContractAddress, entrypoint: starknetSelector(from: "transfer"), calldata: calldata1)
-        let call2 = StarknetCall(contractAddress: DevnetClient.erc20ContractAddress, entrypoint: starknetSelector(from: "transfer"), calldata: calldata2)
+        let call1 = StarknetCall(contractAddress: AccountTests.devnetClient.constants.erc20ContractAddress, entrypoint: starknetSelector(from: "transfer"), calldata: calldata1)
+        let call2 = StarknetCall(contractAddress: AccountTests.devnetClient.constants.erc20ContractAddress, entrypoint: starknetSelector(from: "transfer"), calldata: calldata2)
 
         let result = try await account.execute(calls: [call1, call2])
 

--- a/Tests/StarknetTests/Data/ExecutionTests.swift
+++ b/Tests/StarknetTests/Data/ExecutionTests.swift
@@ -18,7 +18,7 @@ final class ExecutionTests: XCTestCase {
         }
 
         provider = StarknetProvider(starknetChainId: .testnet, url: Self.devnetClient.rpcUrl)!
-        let accountDetails = DevnetClient.predeployedAccount1
+        let accountDetails = ExecutionTests.devnetClient.constants.predeployedAccount1
         signer = StarkCurveSigner(privateKey: accountDetails.privateKey)!
         account = StarknetAccount(address: accountDetails.address, signer: signer, provider: provider, cairoVersion: .one)
         balanceContractAddress = try await Self.devnetClient.declareDeployContract(contractName: "Balance").deploy.contractAddress

--- a/Tests/StarknetTests/Devnet/DevnetClientTests.swift
+++ b/Tests/StarknetTests/Devnet/DevnetClientTests.swift
@@ -49,11 +49,11 @@ final class devnetClientTests: XCTestCase {
 
     func testInvokeContract() async throws {
         let calldata = [
-            DevnetClient.predeployedAccount1.address,
+            client.constants.predeployedAccount1.address,
             1000,
             0,
         ]
-        let invokeResult = try await client.invokeContract(contractAddress: DevnetClient.erc20ContractAddress, function: "transfer", calldata: calldata)
+        let invokeResult = try await client.invokeContract(contractAddress: client.constants.erc20ContractAddress, function: "transfer", calldata: calldata)
         try await client.assertTransactionSucceeded(transactionHash: invokeResult.transactionHash)
     }
 }

--- a/Tests/StarknetTests/Providers/ProviderTests.swift
+++ b/Tests/StarknetTests/Providers/ProviderTests.swift
@@ -33,7 +33,7 @@ final class ProviderTests: XCTestCase {
 
     func testCall() async throws {
         let call = StarknetCall(
-            contractAddress: DevnetClient.predeployedAccount1.address,
+            contractAddress: ProviderTests.devnetClient.constants.predeployedAccount1.address,
             entrypoint: starknetSelector(from: "getPublicKey"),
             calldata: []
         )
@@ -42,7 +42,7 @@ final class ProviderTests: XCTestCase {
             let result = try await provider.callContract(call)
 
             XCTAssertEqual(result.count, 1)
-            XCTAssertEqual(result[0], DevnetClient.predeployedAccount1.publicKey)
+            XCTAssertEqual(result[0], ProviderTests.devnetClient.constants.predeployedAccount1.publicKey)
         } catch let e {
             print(e)
             throw e
@@ -51,7 +51,7 @@ final class ProviderTests: XCTestCase {
 
     func testCallWithArguments() async throws {
         let call = StarknetCall(
-            contractAddress: DevnetClient.predeployedAccount1.address,
+            contractAddress: ProviderTests.devnetClient.constants.predeployedAccount1.address,
             entrypoint: starknetSelector(from: "supportsInterface"),
             calldata: [Felt(2138)]
         )
@@ -62,7 +62,7 @@ final class ProviderTests: XCTestCase {
     }
 
     func testGetNonce() async throws {
-        let nonce = try await provider.getNonce(of: DevnetClient.predeployedAccount1.address)
+        let nonce = try await provider.getNonce(of: ProviderTests.devnetClient.constants.predeployedAccount1.address)
 
         print(nonce)
     }

--- a/Tests/StarknetTests/Utils/DevnetClient/DevnetClient.swift
+++ b/Tests/StarknetTests/Utils/DevnetClient/DevnetClient.swift
@@ -11,6 +11,8 @@ protocol DevnetClientProtocol {
     var seed: Int { get }
     var baseUrl: String { get }
 
+    var constants: DevnetClientConstants.Type { get }
+
     func start() async throws
     func close()
 
@@ -38,7 +40,7 @@ extension DevnetClientProtocol {
 
     func createDeployAccount(
         name: String,
-        classHash: Felt = DevnetClient.accountContractClassHash,
+        classHash: Felt = DevnetClientConstants.accountContractClassHash,
         salt: Felt? = .zero,
         maxFee: Felt = 1_000_000_000_000_000
     ) async throws -> DeployAccountResult {
@@ -53,7 +55,7 @@ extension DevnetClientProtocol {
     func createDeployAccount() async throws -> DeployAccountResult {
         try await createDeployAccount(
             name: UUID().uuidString,
-            classHash: DevnetClient.accountContractClassHash,
+            classHash: DevnetClientConstants.accountContractClassHash,
             salt: .zero,
             maxFee: 1_000_000_000_000_000
         )
@@ -61,7 +63,7 @@ extension DevnetClientProtocol {
 
     func createAccount(
         name: String,
-        classHash: Felt = DevnetClient.accountContractClassHash,
+        classHash: Felt = DevnetClientConstants.accountContractClassHash,
         salt: Felt? = .zero
     ) async throws -> CreateAccountResult {
         try await createAccount(
@@ -74,14 +76,14 @@ extension DevnetClientProtocol {
     func createAccount() async throws -> CreateAccountResult {
         try await createAccount(
             name: UUID().uuidString,
-            classHash: DevnetClient.accountContractClassHash,
+            classHash: DevnetClientConstants.accountContractClassHash,
             salt: .zero
         )
     }
 
     func deployAccount(
         name: String,
-        classHash: Felt = DevnetClient.accountContractClassHash,
+        classHash: Felt = DevnetClientConstants.accountContractClassHash,
         maxFee: Felt = 1_000_000_000_000_000,
         prefund: Bool = true
     ) async throws -> DeployAccountResult {
@@ -168,21 +170,14 @@ func makeDevnetClient() -> DevnetClientProtocol {
         private var declaredContractsAtName: [String: DeclareContractResult] = [:]
         private var deployedContracts: [Felt: DeployContractResult] = [:]
 
-        // Source: https://github.com/0xSpaceShard/starknet-devnet-rs/blob/323f907bc3e3e4dc66b403ec6f8b58744e8d6f9a/crates/starknet/src/constants.rs
-        public static let accountContractClassHash: Felt = "0x4d07e40e93398ed3c76981e72dd1fd22557a78ce36c0515f679e27f0bb5bc5f"
-        public static let erc20ContractClassHash: Felt = "0x6a22bf63c7bc07effa39a25dfbd21523d211db0100a0afd054d172b81840eaf"
-        public static let erc20ContractAddress: Felt = "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
-        public static let udcContractClassHash: Felt = "0x7b3e05f48f0c69e4a65ce5e076a66271a527aff2c34ce1083ec6e1526997a69"
-        public static let udcContractAddress: Felt = "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf"
-        public static let predeployedAccount1: AccountDetails = .init(privateKey: "0xa2ed22bb0cb0b49c69f6d6a8d24bc5ea", publicKey: "0x198e98e771ebb5da7f4f05658a80a3d6be2213dc5096d055cbbefa62901ab06", address: "0x1323cacbc02b4aaed9bb6b24d121fb712d8946376040990f2f2fa0dcf17bb5b", salt: 20)
-        public static let predeployedAccount2: AccountDetails = .init(privateKey: "0xc1c7db92d22ef773de96f8bde8e56c85", publicKey: "0x26df62f8e61920575f9c9391ed5f08397cfcfd2ade02d47781a4a8836c091fd", address: "0x34864aab9f693157f88f2213ffdaa7303a46bbea92b702416a648c3d0e42f35", salt: 20)
-
         let host: String
         let port: Int
         let seed: Int
         let baseUrl: String
         let rpcUrl: String
         let mintUrl: String
+
+        let constants: DevnetClientConstants.Type = DevnetClientConstants.self
 
         init(host: String = "127.0.0.1", port: Int = 5051, seed: Int = 1_053_545_547) {
             self.host = host
@@ -331,7 +326,7 @@ func makeDevnetClient() -> DevnetClientProtocol {
 
         public func createDeployAccount(
             name: String,
-            classHash: Felt = DevnetClient.accountContractClassHash,
+            classHash: Felt = DevnetClientConstants.accountContractClassHash,
             salt: Felt? = nil,
             maxFee: Felt = 1_000_000_000_000_000
         ) async throws -> DeployAccountResult {
@@ -350,7 +345,7 @@ func makeDevnetClient() -> DevnetClientProtocol {
 
         public func createAccount(
             name: String,
-            classHash: Felt = accountContractClassHash,
+            classHash: Felt = DevnetClientConstants.accountContractClassHash,
             salt: Felt? = nil
         ) async throws -> CreateAccountResult {
             var params = [
@@ -381,7 +376,7 @@ func makeDevnetClient() -> DevnetClientProtocol {
 
         public func deployAccount(
             name: String,
-            classHash: Felt = accountContractClassHash,
+            classHash: Felt = DevnetClientConstants.accountContractClassHash,
             maxFee: Felt = 1_000_000_000_000_000,
             prefund: Bool = true
         ) async throws -> DeployAccountResult {

--- a/Tests/StarknetTests/Utils/DevnetClient/DevnetClientModels.swift
+++ b/Tests/StarknetTests/Utils/DevnetClient/DevnetClientModels.swift
@@ -2,6 +2,19 @@ import BigInt
 import Foundation
 import Starknet
 
+enum DevnetClientConstants {
+    // Source: https://github.com/0xSpaceShard/starknet-devnet-rs/blob/323f907bc3e3e4dc66b403ec6f8b58744e8d6f9a/crates/starknet/src/constants.rs
+    static let accountContractClassHash: Felt = "0x4d07e40e93398ed3c76981e72dd1fd22557a78ce36c0515f679e27f0bb5bc5f"
+    static let erc20ContractClassHash: Felt = "0x6a22bf63c7bc07effa39a25dfbd21523d211db0100a0afd054d172b81840eaf"
+    static let erc20ContractAddress: Felt = "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
+    static let udcContractClassHash: Felt = "0x7b3e05f48f0c69e4a65ce5e076a66271a527aff2c34ce1083ec6e1526997a69"
+    static let udcContractAddress: Felt = "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf"
+    // Source: starknet-devnet-rs cli
+    // Only for seed 1_053_545_547
+    static let predeployedAccount1: AccountDetails = .init(privateKey: "0xa2ed22bb0cb0b49c69f6d6a8d24bc5ea", publicKey: "0x198e98e771ebb5da7f4f05658a80a3d6be2213dc5096d055cbbefa62901ab06", address: "0x1323cacbc02b4aaed9bb6b24d121fb712d8946376040990f2f2fa0dcf17bb5b", salt: 20)
+    static let predeployedAccount2: AccountDetails = .init(privateKey: "0xc1c7db92d22ef773de96f8bde8e56c85", publicKey: "0x26df62f8e61920575f9c9391ed5f08397cfcfd2ade02d47781a4a8836c091fd", address: "0x34864aab9f693157f88f2213ffdaa7303a46bbea92b702416a648c3d0e42f35", salt: 20)
+}
+
 struct AccountDetails: Codable {
     let privateKey: Felt
     let publicKey: Felt


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

The `xcodebuild docbuild` command is the part of release CI workflow, which currently fails because of this command.
Apparently, the reason is using static values from `DevnetClient`, which fails because `DevnetClient` is **internal**, even though building and testing using XCode istelf works without issue despite that. 

Since we probably want to keep `DevnetClient` and classes it uses **internal**, we could instead use enum `DevnetClientConstants` to hold the constants. We could then:
- Access `DevnetClientConstants` in methods inside `DevnetClient` methods when we need default values for arguments.
- Add `constants` field to easily access constants from `DevnetClientProtocol` from outside without needing to be aware of `DevnetClientConstants`.

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #108  

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
