### PR TITLE
Support Sepolia network; Support `starknet_chainId` endpoint

### DIFF
--- a/Sources/Starknet/Accounts/StarknetAccount.swift
+++ b/Sources/Starknet/Accounts/StarknetAccount.swift
@@ -40,44 +40,48 @@ public class StarknetAccount: StarknetAccountProtocol {
         StarknetDeployAccountTransactionV3(signature: signature, l1ResourceBounds: params.resourceBounds.l1Gas, nonce: params.nonce, contractAddressSalt: salt, constructorCalldata: calldata, classHash: classHash, forFeeEstimation: forFeeEstimation)
     }
 
-    public func signV1(calls: [StarknetCall], params: StarknetInvokeParamsV1, forFeeEstimation: Bool) throws -> StarknetInvokeTransactionV1 {
+    public func signV1(calls: [StarknetCall], params: StarknetInvokeParamsV1, forFeeEstimation: Bool) async throws -> StarknetInvokeTransactionV1 {
         let calldata = starknetCallsToExecuteCalldata(calls: calls, cairoVersion: cairoVersion)
 
         let transaction = makeInvokeTransactionV1(calldata: calldata, signature: [], params: params, forFeeEstimation: forFeeEstimation)
 
-        let hash = StarknetTransactionHashCalculator.computeHash(of: transaction, chainId: provider.starknetChainId)
+        let chainId = try await provider.getChainId()
+        let hash = StarknetTransactionHashCalculator.computeHash(of: transaction, chainId: chainId)
 
         let signature = try signer.sign(transactionHash: hash)
 
         return makeInvokeTransactionV1(calldata: calldata, signature: signature, params: params, forFeeEstimation: forFeeEstimation)
     }
 
-    public func signV3(calls: [StarknetCall], params: StarknetInvokeParamsV3, forFeeEstimation: Bool) throws -> StarknetInvokeTransactionV3 {
+    public func signV3(calls: [StarknetCall], params: StarknetInvokeParamsV3, forFeeEstimation: Bool) async throws -> StarknetInvokeTransactionV3 {
         let calldata = starknetCallsToExecuteCalldata(calls: calls, cairoVersion: cairoVersion)
 
         let transaction = makeInvokeTransactionV3(calldata: calldata, signature: [], params: params, forFeeEstimation: forFeeEstimation)
 
-        let hash = StarknetTransactionHashCalculator.computeHash(of: transaction, chainId: provider.starknetChainId)
+        let chainId = try await provider.getChainId()
+        let hash = StarknetTransactionHashCalculator.computeHash(of: transaction, chainId: chainId)
 
         let signature = try signer.sign(transactionHash: hash)
 
         return makeInvokeTransactionV3(calldata: calldata, signature: signature, params: params, forFeeEstimation: forFeeEstimation)
     }
 
-    public func signDeployAccountV1(classHash: Felt, calldata: StarknetCalldata, salt: Felt, params: StarknetDeployAccountParamsV1, forFeeEstimation: Bool) throws -> StarknetDeployAccountTransactionV1 {
+    public func signDeployAccountV1(classHash: Felt, calldata: StarknetCalldata, salt: Felt, params: StarknetDeployAccountParamsV1, forFeeEstimation: Bool) async throws -> StarknetDeployAccountTransactionV1 {
         let transaction = makeDeployAccountTransactionV1(classHash: classHash, salt: salt, calldata: calldata, signature: [], params: params, forFeeEstimation: forFeeEstimation)
 
-        let hash = StarknetTransactionHashCalculator.computeHash(of: transaction, chainId: provider.starknetChainId)
+        let chainId = try await provider.getChainId()
+        let hash = StarknetTransactionHashCalculator.computeHash(of: transaction, chainId: chainId)
 
         let signature = try signer.sign(transactionHash: hash)
 
         return makeDeployAccountTransactionV1(classHash: classHash, salt: salt, calldata: calldata, signature: signature, params: params, forFeeEstimation: forFeeEstimation)
     }
 
-    public func signDeployAccountV3(classHash: Felt, calldata: StarknetCalldata, salt: Felt, params: StarknetDeployAccountParamsV3, forFeeEstimation: Bool) throws -> StarknetDeployAccountTransactionV3 {
+    public func signDeployAccountV3(classHash: Felt, calldata: StarknetCalldata, salt: Felt, params: StarknetDeployAccountParamsV3, forFeeEstimation: Bool) async throws -> StarknetDeployAccountTransactionV3 {
         let transaction = makeDeployAccountTransactionV3(classHash: classHash, salt: salt, calldata: calldata, signature: [], params: params, forFeeEstimation: forFeeEstimation)
 
-        let hash = StarknetTransactionHashCalculator.computeHash(of: transaction, chainId: provider.starknetChainId)
+        let chainId = try await provider.getChainId()
+        let hash = StarknetTransactionHashCalculator.computeHash(of: transaction, chainId: chainId)
 
         let signature = try signer.sign(transactionHash: hash)
 
@@ -102,7 +106,7 @@ public class StarknetAccount: StarknetAccountProtocol {
         }
 
         let params = StarknetInvokeParamsV1(nonce: nonce, maxFee: maxFee)
-        let signedTransaction = try signV1(calls: calls, params: params, forFeeEstimation: false)
+        let signedTransaction = try await signV1(calls: calls, params: params, forFeeEstimation: false)
 
         return try await provider.addInvokeTransaction(signedTransaction)
     }
@@ -125,35 +129,35 @@ public class StarknetAccount: StarknetAccountProtocol {
         }
 
         let params = StarknetInvokeParamsV3(nonce: nonce, l1ResourceBounds: resourceBounds.l1Gas)
-        let signedTransaction = try signV3(calls: calls, params: params, forFeeEstimation: false)
+        let signedTransaction = try await signV3(calls: calls, params: params, forFeeEstimation: false)
 
         return try await provider.addInvokeTransaction(signedTransaction)
     }
 
     public func estimateFeeV1(calls: [StarknetCall], nonce: Felt, skipValidate: Bool) async throws -> StarknetFeeEstimate {
         let params = StarknetInvokeParamsV1(nonce: nonce, maxFee: .zero)
-        let signedTransaction = try signV1(calls: calls, params: params, forFeeEstimation: true)
+        let signedTransaction = try await signV1(calls: calls, params: params, forFeeEstimation: true)
 
         return try await provider.estimateFee(for: signedTransaction, simulationFlags: skipValidate ? [.skipValidate] : [])
     }
 
     public func estimateFeeV3(calls: [StarknetCall], nonce: Felt, skipValidate: Bool) async throws -> StarknetFeeEstimate {
         let params = StarknetInvokeParamsV3(nonce: nonce, l1ResourceBounds: .zero)
-        let signedTransaction = try signV3(calls: calls, params: params, forFeeEstimation: true)
+        let signedTransaction = try await signV3(calls: calls, params: params, forFeeEstimation: true)
 
         return try await provider.estimateFee(for: signedTransaction, simulationFlags: skipValidate ? [.skipValidate] : [])
     }
 
     public func estimateDeployAccountFeeV1(classHash: Felt, calldata: StarknetCalldata, salt: Felt, nonce: Felt, skipValidate: Bool) async throws -> StarknetFeeEstimate {
         let params = StarknetDeployAccountParamsV1(nonce: nonce, maxFee: 0)
-        let signedTransaction = try signDeployAccountV1(classHash: classHash, calldata: calldata, salt: salt, params: params, forFeeEstimation: true)
+        let signedTransaction = try await signDeployAccountV1(classHash: classHash, calldata: calldata, salt: salt, params: params, forFeeEstimation: true)
 
         return try await provider.estimateFee(for: signedTransaction, simulationFlags: skipValidate ? [.skipValidate] : [])
     }
 
     public func estimateDeployAccountFeeV3(classHash: Felt, calldata: StarknetCalldata, salt: Felt, nonce: Felt, skipValidate: Bool) async throws -> StarknetFeeEstimate {
         let params = StarknetDeployAccountParamsV3(nonce: nonce, l1ResourceBounds: .zero)
-        let signedTransaction = try signDeployAccountV3(classHash: classHash, calldata: calldata, salt: salt, params: params, forFeeEstimation: true)
+        let signedTransaction = try await signDeployAccountV3(classHash: classHash, calldata: calldata, salt: salt, params: params, forFeeEstimation: true)
 
         return try await provider.estimateFee(for: signedTransaction, simulationFlags: skipValidate ? [.skipValidate] : [])
     }

--- a/Sources/Starknet/Accounts/StarknetAccountProtocol.swift
+++ b/Sources/Starknet/Accounts/StarknetAccountProtocol.swift
@@ -12,7 +12,7 @@ public protocol StarknetAccountProtocol {
     ///  - forFeeEstimation: Flag indicating whether the different version of transaction should be used; such transaction can only be used for fee estimation
     ///
     /// - Returns: Signed invoke v1 transaction
-    func signV1(calls: [StarknetCall], params: StarknetInvokeParamsV1, forFeeEstimation: Bool) throws -> StarknetInvokeTransactionV1
+    func signV1(calls: [StarknetCall], params: StarknetInvokeParamsV1, forFeeEstimation: Bool) async throws -> StarknetInvokeTransactionV1
 
     /// Sign list of calls as invoke transaction v3
     ///
@@ -22,7 +22,7 @@ public protocol StarknetAccountProtocol {
     ///  - forFeeEstimation: Flag indicating whether the different version of transaction should be used; such transaction can only be used for fee estimation
     ///
     /// - Returns: Signed invoke v3 transaction
-    func signV3(calls: [StarknetCall], params: StarknetInvokeParamsV3, forFeeEstimation: Bool) throws -> StarknetInvokeTransactionV3
+    func signV3(calls: [StarknetCall], params: StarknetInvokeParamsV3, forFeeEstimation: Bool) async throws -> StarknetInvokeTransactionV3
 
     /// Create and sign deploy account transaction v1
     ///
@@ -34,7 +34,7 @@ public protocol StarknetAccountProtocol {
     ///  - forFeeEstimation: Flag indicating whether the different version of transaction should be used; such transaction can only be used for fee estimation
     ///
     /// - Returns: Signed deploy account transaction v1
-    func signDeployAccountV1(classHash: Felt, calldata: StarknetCalldata, salt: Felt, params: StarknetDeployAccountParamsV1, forFeeEstimation: Bool) throws -> StarknetDeployAccountTransactionV1
+    func signDeployAccountV1(classHash: Felt, calldata: StarknetCalldata, salt: Felt, params: StarknetDeployAccountParamsV1, forFeeEstimation: Bool) async throws -> StarknetDeployAccountTransactionV1
 
     /// Create and sign deploy account transaction v3
     ///
@@ -46,7 +46,7 @@ public protocol StarknetAccountProtocol {
     ///  - forFeeEstimation: Flag indicating whether the different version of transaction should be used; such transaction can only be used for fee estimation
     ///
     /// - Returns: Signed deploy account transaction v3
-    func signDeployAccountV3(classHash: Felt, calldata: StarknetCalldata, salt: Felt, params: StarknetDeployAccountParamsV3, forFeeEstimation: Bool) throws -> StarknetDeployAccountTransactionV3
+    func signDeployAccountV3(classHash: Felt, calldata: StarknetCalldata, salt: Felt, params: StarknetDeployAccountParamsV3, forFeeEstimation: Bool) async throws -> StarknetDeployAccountTransactionV3
 
     /// Sign TypedData for off-chain usage with this account's privateKey.
     ///
@@ -54,7 +54,7 @@ public protocol StarknetAccountProtocol {
     ///  - typedData: a TypedData object to sign
     ///
     /// - Returns: a signature for provided TypedData object.
-    func sign(typedData: StarknetTypedData) throws -> StarknetSignature
+    func sign(typedData: StarknetTypedData) async throws -> StarknetSignature
 
     /// Verify a signature of TypedData on Starknet.
     ///
@@ -158,8 +158,8 @@ public extension StarknetAccountProtocol {
     ///  - params: additional params for a given transaction
     ///
     /// - Returns: Signed invoke transaction v1
-    func signV1(calls: [StarknetCall], params: StarknetInvokeParamsV1) throws -> StarknetInvokeTransactionV1 {
-        try signV1(calls: calls, params: params, forFeeEstimation: false)
+    func signV1(calls: [StarknetCall], params: StarknetInvokeParamsV1) async throws -> StarknetInvokeTransactionV1 {
+        try await signV1(calls: calls, params: params, forFeeEstimation: false)
     }
 
     /// Sign list of calls for execution as invoke transaction v3.
@@ -170,8 +170,8 @@ public extension StarknetAccountProtocol {
     ///  - params: additional params for a given transaction
     ///
     /// - Returns: Signed invoke transaction v3
-    func signV3(calls: [StarknetCall], params: StarknetInvokeParamsV3) throws -> StarknetInvokeTransactionV3 {
-        try signV3(calls: calls, params: params, forFeeEstimation: false)
+    func signV3(calls: [StarknetCall], params: StarknetInvokeParamsV3) async throws -> StarknetInvokeTransactionV3 {
+        try await signV3(calls: calls, params: params, forFeeEstimation: false)
     }
 
     /// Create and sign deploy account transaction v1
@@ -184,8 +184,8 @@ public extension StarknetAccountProtocol {
     ///  - maxFee: max acceptable fee for the transaction
     ///
     /// - Returns: Signed deploy account transaction v1
-    func signDeployAccountV1(classHash: Felt, calldata: StarknetCalldata, salt: Felt, maxFee: Felt) throws -> StarknetDeployAccountTransactionV1 {
-        try signDeployAccountV1(classHash: classHash, calldata: calldata, salt: salt, params: StarknetDeployAccountParamsV1(nonce: .zero, maxFee: maxFee), forFeeEstimation: false)
+    func signDeployAccountV1(classHash: Felt, calldata: StarknetCalldata, salt: Felt, maxFee: Felt) async throws -> StarknetDeployAccountTransactionV1 {
+        try await signDeployAccountV1(classHash: classHash, calldata: calldata, salt: salt, params: StarknetDeployAccountParamsV1(nonce: .zero, maxFee: maxFee), forFeeEstimation: false)
     }
 
     /// Create and sign deploy account transaction v3
@@ -198,8 +198,8 @@ public extension StarknetAccountProtocol {
     ///  - l1ResourceBounds: max acceptable l1 resource bounds
     ///
     /// - Returns: Signed deploy account transaction v3
-    func signDeployAccountV3(classHash: Felt, calldata: StarknetCalldata, salt: Felt, l1ResourceBounds: StarknetResourceBounds) throws -> StarknetDeployAccountTransactionV3 {
-        try signDeployAccountV3(classHash: classHash, calldata: calldata, salt: salt, params: StarknetDeployAccountParamsV3(nonce: .zero, l1ResourceBounds: l1ResourceBounds), forFeeEstimation: false)
+    func signDeployAccountV3(classHash: Felt, calldata: StarknetCalldata, salt: Felt, l1ResourceBounds: StarknetResourceBounds) async throws -> StarknetDeployAccountTransactionV3 {
+        try await signDeployAccountV3(classHash: classHash, calldata: calldata, salt: salt, params: StarknetDeployAccountParamsV3(nonce: .zero, l1ResourceBounds: l1ResourceBounds), forFeeEstimation: false)
     }
 
     /// Sign a call as invoke transaction v1
@@ -210,8 +210,8 @@ public extension StarknetAccountProtocol {
     ///  - forFeeEstimation: Flag indicating whether the different version of transaction should be used; such transaction can only be used for fee estimation
     ///
     /// - Returns: Signed invoke transaction v1
-    func signV1(call: StarknetCall, params: StarknetInvokeParamsV1, forFeeEstimation: Bool = false) throws -> StarknetInvokeTransactionV1 {
-        try signV1(calls: [call], params: params, forFeeEstimation: forFeeEstimation)
+    func signV1(call: StarknetCall, params: StarknetInvokeParamsV1, forFeeEstimation: Bool = false) async throws -> StarknetInvokeTransactionV1 {
+        try await signV1(calls: [call], params: params, forFeeEstimation: forFeeEstimation)
     }
 
     /// Sign a call as invoke transaction v3
@@ -221,8 +221,8 @@ public extension StarknetAccountProtocol {
     ///  - forFeeEstimation: Flag indicating whether the different version of transaction should be used; such transaction can only be used for fee estimation
     ///
     /// - Returns: Signed invoke transaction v3
-    func signV3(call: StarknetCall, params: StarknetInvokeParamsV3, forFeeEstimation: Bool = false) throws -> StarknetInvokeTransactionV3 {
-        try signV3(calls: [call], params: params, forFeeEstimation: forFeeEstimation)
+    func signV3(call: StarknetCall, params: StarknetInvokeParamsV3, forFeeEstimation: Bool = false) async throws -> StarknetInvokeTransactionV3 {
+        try await signV3(calls: [call], params: params, forFeeEstimation: forFeeEstimation)
     }
 
     /// Execute list of calls as invoke transaction v1

--- a/Sources/Starknet/Data/StarknetChainId.swift
+++ b/Sources/Starknet/Data/StarknetChainId.swift
@@ -1,16 +1,20 @@
 import BigInt
 import Foundation
 
-public enum StarknetChainId {
-    case mainnet
-    case testnet
+public enum StarknetChainId: String, Codable, Equatable {
+    case mainnet = "0x534e5f4d41494e"
+    case goerli = "0x534e5f474f45524c49"
+    case sepolia_testnet = "0x534e5f5345504f4c4941"
+    case sepolia_integration = "0x534e5f494e544547524154494f4e5f5345504f4c4941"
 
     public var feltValue: Felt {
-        switch self {
-        case .mainnet:
-            return Felt(fromHex: "0x534e5f4d41494e")!
-        case .testnet:
-            return Felt(fromHex: "0x534e5f474f45524c49")!
-        }
+        Felt(fromHex: self.rawValue)!
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case mainnet = "0x534e5f4d41494e"
+        case goerli = "0x534e5f474f45524c49"
+        case sepolia_testnet = "0x534e5f5345504f4c4941"
+        case sepolia_integration = "0x534e5f494e544547524154494f4e5f5345504f4c4941"
     }
 }

--- a/Sources/Starknet/Providers/StarknetProvider/JsonRpcMethod.swift
+++ b/Sources/Starknet/Providers/StarknetProvider/JsonRpcMethod.swift
@@ -14,7 +14,8 @@ enum JsonRpcMethod: String, Encodable {
     case getTransactionByHash = "starknet_getTransactionByHash"
     case getTransactionByBlockIdAndIndex = "starknet_getTransactionByBlockIdAndIndex"
     case getTransactionReceipt = "starknet_getTransactionReceipt"
+    case getTransactionStatus = "starknet_getTransactionStatus"
+    case getChainId = "starknet_chainId"
     case simulateTransactions = "starknet_simulateTransactions"
     case estimateMessageFee = "starknet_estimateMessageFee"
-    case getTransactionStatus = "starknet_getTransactionStatus"
 }

--- a/Sources/Starknet/Providers/StarknetProvider/StarknetProvider.swift
+++ b/Sources/Starknet/Providers/StarknetProvider/StarknetProvider.swift
@@ -15,7 +15,7 @@ public class StarknetProvider: StarknetProviderProtocol {
         self.networkProvider = HttpNetworkProvider()
     }
 
-    public convenience init?(starknetChainId _: StarknetChainId, url: String) {
+    public convenience init?(url: String) {
         guard let url = URL(string: url) else {
             return nil
         }

--- a/Sources/Starknet/Providers/StarknetProvider/StarknetProvider.swift
+++ b/Sources/Starknet/Providers/StarknetProvider/StarknetProvider.swift
@@ -182,6 +182,14 @@ public class StarknetProvider: StarknetProviderProtocol {
         return result
     }
 
+    public func getChainId() async throws -> StarknetChainId {
+        let params = EmptySequence()
+
+        let result = try await makeRequest(method: .getChainId, params: params, receive: StarknetChainId.self)
+
+        return result
+    }
+
     public func simulateTransactions(_ transactions: [any StarknetExecutableTransaction], at blockId: StarknetBlockId, simulationFlags: Set<StarknetSimulationFlag>) async throws -> [StarknetSimulatedTransaction] {
         let params = SimulateTransactionsParams(transactions: transactions, blockId: blockId, simulationFlags: simulationFlags)
 

--- a/Sources/Starknet/Providers/StarknetProvider/StarknetProvider.swift
+++ b/Sources/Starknet/Providers/StarknetProvider/StarknetProvider.swift
@@ -7,35 +7,31 @@ public enum StarknetProviderError: Error {
 }
 
 public class StarknetProvider: StarknetProviderProtocol {
-    public let starknetChainId: StarknetChainId
-
     private let url: URL
     private let networkProvider: HttpNetworkProvider
 
-    public init(starknetChainId: StarknetChainId, url: URL) {
-        self.starknetChainId = starknetChainId
+    public init(url: URL) {
         self.url = url
         self.networkProvider = HttpNetworkProvider()
     }
 
-    public convenience init?(starknetChainId: StarknetChainId, url: String) {
+    public convenience init?(starknetChainId _: StarknetChainId, url: String) {
         guard let url = URL(string: url) else {
             return nil
         }
-        self.init(starknetChainId: starknetChainId, url: url)
+        self.init(url: url)
     }
 
-    public init(starknetChainId: StarknetChainId, url: URL, urlSession: URLSession) {
-        self.starknetChainId = starknetChainId
+    public init(url: URL, urlSession: URLSession) {
         self.url = url
         self.networkProvider = HttpNetworkProvider(session: urlSession)
     }
 
-    public convenience init?(starknetChainId: StarknetChainId, url: String, urlSession: URLSession) {
+    public convenience init?(url: String, urlSession: URLSession) {
         guard let url = URL(string: url) else {
             return nil
         }
-        self.init(starknetChainId: starknetChainId, url: url, urlSession: urlSession)
+        self.init(url: url, urlSession: urlSession)
     }
 
     private func makeRequest<U>(method: JsonRpcMethod, params: some Encodable = EmptyParams(), receive _: U.Type) async throws -> U where U: Decodable {

--- a/Sources/Starknet/Providers/StarknetProviderProtocol.swift
+++ b/Sources/Starknet/Providers/StarknetProviderProtocol.swift
@@ -2,8 +2,6 @@ import Foundation
 
 /// Provider used to interact with the StakNet blockchain.
 public protocol StarknetProviderProtocol {
-    var starknetChainId: StarknetChainId { get }
-
     /// Get the version of the Starknet JSON-RPC specification being used by the node.
     ///
     ///  - Returns: the version of the Starknet JSON-RPC specification being used.

--- a/Sources/Starknet/Providers/StarknetProviderProtocol.swift
+++ b/Sources/Starknet/Providers/StarknetProviderProtocol.swift
@@ -126,6 +126,11 @@ public protocol StarknetProviderProtocol {
     /// - Returns: The status(es) of a transaction
     func getTransactionStatusBy(hash: Felt) async throws -> StarknetGetTransactionStatusResponse
 
+    /// Get the currently configured Starknet chain id
+    ///
+    /// - Returns: The Starknet chain id
+    func getChainId() async throws -> StarknetChainId
+
     /// Simulate running a given list of transactions, and generate the execution trace
     ///
     /// - Parameters:

--- a/Tests/StarknetTests/Accounts/AccountTest.swift
+++ b/Tests/StarknetTests/Accounts/AccountTest.swift
@@ -18,7 +18,7 @@ final class AccountTests: XCTestCase {
             try await Self.devnetClient.start()
         }
 
-        provider = StarknetProvider(starknetChainId: .testnet, url: Self.devnetClient.rpcUrl)!
+        provider = StarknetProvider(starknetChainId: .goerli, url: Self.devnetClient.rpcUrl)!
         accountContractClassHash = Self.devnetClient.constants.accountContractClassHash
         ethContractAddress = Self.devnetClient.constants.ethErc20ContractAddress
         let accountDetails = Self.devnetClient.constants.predeployedAccount1
@@ -157,7 +157,7 @@ final class AccountTests: XCTestCase {
 
         let params = StarknetDeployAccountParamsV1(nonce: nonce, maxFee: maxFee)
 
-        let deployAccountTransaction = try newAccount.signDeployAccountV1(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero, params: params, forFeeEstimation: false)
+        let deployAccountTransaction = try await newAccount.signDeployAccountV1(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero, params: params, forFeeEstimation: false)
 
         let response = try await provider.addDeployAccountTransaction(deployAccountTransaction)
 
@@ -182,7 +182,7 @@ final class AccountTests: XCTestCase {
 
         let params = StarknetDeployAccountParamsV3(nonce: nonce, l1ResourceBounds: feeEstimate.toResourceBounds().l1Gas)
 
-        let deployAccountTransaction = try newAccount.signDeployAccountV3(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero, params: params, forFeeEstimation: false)
+        let deployAccountTransaction = try await newAccount.signDeployAccountV3(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero, params: params, forFeeEstimation: false)
 
         let response = try await provider.addDeployAccountTransaction(deployAccountTransaction)
 
@@ -196,7 +196,7 @@ final class AccountTests: XCTestCase {
     func testSignTypedData() async throws {
         let typedData = loadTypedDataFromFile(name: "typed_data_struct_array_example")!
 
-        let signature = try account.sign(typedData: typedData)
+        let signature = try await account.sign(typedData: typedData)
         XCTAssertTrue(signature.count > 0)
 
         let successResult = try await account.verify(signature: signature, for: typedData)

--- a/Tests/StarknetTests/Data/ExecutionTests.swift
+++ b/Tests/StarknetTests/Data/ExecutionTests.swift
@@ -17,7 +17,7 @@ final class ExecutionTests: XCTestCase {
             try await Self.devnetClient.start()
         }
 
-        provider = StarknetProvider(starknetChainId: .testnet, url: Self.devnetClient.rpcUrl)!
+        provider = StarknetProvider(url: Self.devnetClient.rpcUrl)!
         let accountDetails = ExecutionTests.devnetClient.constants.predeployedAccount1
         signer = StarkCurveSigner(privateKey: accountDetails.privateKey)!
         account = StarknetAccount(address: accountDetails.address, signer: signer, provider: provider, cairoVersion: .one)
@@ -37,7 +37,7 @@ final class ExecutionTests: XCTestCase {
         }
     }
 
-    func testStarknetCallsToExecuteCalldataCairo1() throws {
+    func testStarknetCallsToExecuteCalldataCairo1() async throws {
         let call1 = StarknetCall(
             contractAddress: balanceContractAddress,
             entrypoint: starknetSelector(from: "increase_balance"),
@@ -57,7 +57,7 @@ final class ExecutionTests: XCTestCase {
         )
         let params = StarknetInvokeParamsV1(nonce: .zero, maxFee: .zero)
 
-        let signedTx = try account.signV1(calls: [call1, call2, call3], params: params)
+        let signedTx = try await account.signV1(calls: [call1, call2, call3], params: params)
         let expectedCalldata = [
             Felt(3),
             balanceContractAddress,
@@ -78,7 +78,7 @@ final class ExecutionTests: XCTestCase {
 
         XCTAssertEqual(expectedCalldata, signedTx.calldata)
 
-        let signedEmptyTx = try account.signV1(calls: [], params: params)
+        let signedEmptyTx = try await account.signV1(calls: [], params: params)
 
         XCTAssertEqual([.zero], signedEmptyTx.calldata)
     }

--- a/Tests/StarknetTests/Data/TransactionTests.swift
+++ b/Tests/StarknetTests/Data/TransactionTests.swift
@@ -89,7 +89,7 @@ final class TransactionTests: XCTestCase {
             let data = string.data(using: .utf8)!
 
             let decoder = JSONDecoder()
-            var result: TransactionWrapper = try decoder.decode(TransactionWrapper.self, from: data)
+            let result: TransactionWrapper = try decoder.decode(TransactionWrapper.self, from: data)
             XCTAssertNotNil(result.transaction)
             XCTAssertTrue(result.transaction.type == type && result.transaction.version == version)
         }

--- a/Tests/StarknetTests/Providers/ProviderTests.swift
+++ b/Tests/StarknetTests/Providers/ProviderTests.swift
@@ -37,14 +37,13 @@ final class ProviderTests: XCTestCase {
     }
 
     func makeStarknetProvider(url: String) -> StarknetProviderProtocol {
-        StarknetProvider(starknetChainId: .testnet, url: url)!
+        StarknetProvider(starknetChainId: .goerli, url: url)!
     }
 
     func testRequestWithCustomURLSession() {
-        let starknetChainId = StarknetChainId.testnet
         let url = Self.devnetClient.rpcUrl
         let customURLSession = URLSession(configuration: .ephemeral)
-        let starknetProvider = StarknetProvider(starknetChainId: starknetChainId, url: url, urlSession: customURLSession)
+        let starknetProvider = StarknetProvider(url: url, urlSession: customURLSession)
 
         XCTAssertNotNil(starknetProvider)
     }
@@ -203,10 +202,10 @@ final class ProviderTests: XCTestCase {
         let call2 = StarknetCall(contractAddress: contractAddress, entrypoint: starknetSelector(from: "increase_balance"), calldata: [100_000_000_000])
 
         let params1 = StarknetInvokeParamsV1(nonce: nonce, maxFee: 0)
-        let tx1 = try account.signV1(calls: [call], params: params1, forFeeEstimation: true)
+        let tx1 = try await account.signV1(calls: [call], params: params1, forFeeEstimation: true)
 
         let params2 = StarknetInvokeParamsV1(nonce: Felt(nonce.value + 1)!, maxFee: 0)
-        let tx2 = try account.signV1(calls: [call, call2], params: params2, forFeeEstimation: true)
+        let tx2 = try await account.signV1(calls: [call, call2], params: params2, forFeeEstimation: true)
 
         let _ = try await provider.estimateFee(for: [tx1, tx2], simulationFlags: [])
 
@@ -224,10 +223,10 @@ final class ProviderTests: XCTestCase {
         let call2 = StarknetCall(contractAddress: contractAddress, entrypoint: starknetSelector(from: "increase_balance"), calldata: [100_000_000_000])
 
         let params1 = StarknetInvokeParamsV3(nonce: nonce, l1ResourceBounds: .zero)
-        let tx1 = try account.signV3(calls: [call], params: params1, forFeeEstimation: true)
+        let tx1 = try await account.signV3(calls: [call], params: params1, forFeeEstimation: true)
 
         let params2 = StarknetInvokeParamsV3(nonce: Felt(nonce.value + 1)!, l1ResourceBounds: .zero)
-        let tx2 = try account.signV3(calls: [call, call2], params: params2, forFeeEstimation: true)
+        let tx2 = try await account.signV3(calls: [call, call2], params: params2, forFeeEstimation: true)
 
         let _ = try await provider.estimateFee(for: [tx1, tx2], simulationFlags: [])
 
@@ -249,7 +248,7 @@ final class ProviderTests: XCTestCase {
 
         let params = StarknetDeployAccountParamsV1(nonce: nonce, maxFee: .zero)
 
-        let tx = try newAccount.signDeployAccountV1(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero, params: params, forFeeEstimation: true)
+        let tx = try await newAccount.signDeployAccountV1(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero, params: params, forFeeEstimation: true)
 
         let _ = try await provider.estimateFee(for: tx, simulationFlags: [])
 
@@ -270,8 +269,7 @@ final class ProviderTests: XCTestCase {
 
         let params = StarknetDeployAccountParamsV3(nonce: nonce, l1ResourceBounds: .zero)
 
-//        let tx = try newAccount.signDeployAccountV3(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero, params: params, forFeeEstimation: true)
-        let tx = try newAccount.signDeployAccountV3(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero, params: params, forFeeEstimation: true)
+        let tx = try await newAccount.signDeployAccountV3(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero, params: params, forFeeEstimation: true)
 
         let _ = try await provider.estimateFee(for: tx)
 
@@ -312,7 +310,7 @@ final class ProviderTests: XCTestCase {
         let call = StarknetCall(contractAddress: contract.deploy.contractAddress, entrypoint: starknetSelector(from: "increase_balance"), calldata: [1000])
         let params = StarknetInvokeParamsV1(nonce: nonce, maxFee: 500_000_000_000_000)
 
-        let invokeTx = try account.signV1(calls: [call], params: params, forFeeEstimation: false)
+        let invokeTx = try await account.signV1(calls: [call], params: params, forFeeEstimation: false)
 
         let accountClassHash = try await provider.getClassHashAt(account.address)
         let newSigner = StarkCurveSigner(privateKey: 1001)!
@@ -323,7 +321,7 @@ final class ProviderTests: XCTestCase {
         try await Self.devnetClient.prefundAccount(address: newAccountAddress)
 
         let newAccountParams = StarknetDeployAccountParamsV1(nonce: .zero, maxFee: 500_000_000_000_000)
-        let deployAccountTx = try newAccount.signDeployAccountV1(classHash: accountClassHash, calldata: [newPublicKey], salt: .zero, params: newAccountParams, forFeeEstimation: false)
+        let deployAccountTx = try await newAccount.signDeployAccountV1(classHash: accountClassHash, calldata: [newPublicKey], salt: .zero, params: newAccountParams, forFeeEstimation: false)
 
         let simulations = try await provider.simulateTransactions([invokeTx, deployAccountTx], at: .tag(.pending), simulationFlags: [])
 
@@ -353,7 +351,7 @@ final class ProviderTests: XCTestCase {
         let invokeL1Gas = StarknetResourceBounds(maxAmount: 500_000, maxPricePerUnit: 100_000_000_000)
         let params = StarknetInvokeParamsV3(nonce: nonce, l1ResourceBounds: invokeL1Gas)
 
-        let invokeTx = try account.signV3(calls: [call], params: params, forFeeEstimation: false)
+        let invokeTx = try await account.signV3(calls: [call], params: params, forFeeEstimation: false)
 
         let accountClassHash = try await provider.getClassHashAt(account.address)
         let newSigner = StarkCurveSigner(privateKey: 3003)!
@@ -365,7 +363,7 @@ final class ProviderTests: XCTestCase {
 
         let deployAccountL1Gas = StarknetResourceBounds(maxAmount: 500_000, maxPricePerUnit: 100_000_000_000)
         let newAccountParams = StarknetDeployAccountParamsV3(nonce: 0, l1ResourceBounds: deployAccountL1Gas)
-        let deployAccountTx = try newAccount.signDeployAccountV3(classHash: accountClassHash, calldata: [newPublicKey], salt: .zero, params: newAccountParams, forFeeEstimation: false)
+        let deployAccountTx = try await newAccount.signDeployAccountV3(classHash: accountClassHash, calldata: [newPublicKey], salt: .zero, params: newAccountParams, forFeeEstimation: false)
 
         let simulations = try await provider.simulateTransactions([invokeTx, deployAccountTx], at: .tag(.pending), simulationFlags: [])
 

--- a/Tests/StarknetTests/Providers/ProviderTests.swift
+++ b/Tests/StarknetTests/Providers/ProviderTests.swift
@@ -48,6 +48,12 @@ final class ProviderTests: XCTestCase {
         XCTAssertNotNil(starknetProvider)
     }
 
+    func testGetChainId() async throws {
+        let chainId = try await provider.getChainId()
+
+        XCTAssertEqual(chainId, .goerli)
+    }
+
     func testSpecVersion() async throws {
         let result = try await provider.specVersion()
         XCTAssertFalse(result.isEmpty)


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->
- #131 
- #132 
- Minor test adjustments

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #131 
Closes #132 

## Breaking changes

- [x] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->

- All `StarknetAccountProtocol` signing methods are now async
- Removed `starknetChainId` from `StarknetProviderProtocol`; Use `StarknetProviderProtocol.getChainId()` instead
- Removed `starknetChainId` parameter from all `StarknetProvider` constructors 
