### PR TITLE
[0.7.4] Support any data in JsonRpcError

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,7 +2,6 @@ name: Checks
 
 on:
   pull_request:
-    branches: "*"
 
 jobs:
   test_and_lint:

--- a/Sources/Starknet/Providers/StarknetProvider/JsonRpcResponse.swift
+++ b/Sources/Starknet/Providers/StarknetProvider/JsonRpcResponse.swift
@@ -12,8 +12,12 @@ struct JsonRpcError: Decodable {
 
         do {
             let anyDecodable = try container.decode(AnyDecodable.self, forKey: .data)
-            let jsonData = try JSONSerialization.data(withJSONObject: anyDecodable.value)
-            data = String(data: jsonData, encoding: .utf8)
+            if anyDecodable.value is String {
+                data = anyDecodable.value as? String
+            } else {
+                let jsonData = try JSONSerialization.data(withJSONObject: anyDecodable.value)
+                data = String(data: jsonData, encoding: .utf8)
+            }
         } catch {
             data = nil
         }

--- a/Sources/Starknet/Providers/StarknetProvider/JsonRpcResponse.swift
+++ b/Sources/Starknet/Providers/StarknetProvider/JsonRpcResponse.swift
@@ -1,17 +1,29 @@
 import Foundation
 
-struct JsonRpcErrorData: Decodable {
-    let revertError: String
-
-    enum CodingKeys: String, CodingKey {
-        case revertError = "revert_error"
-    }
-}
-
 struct JsonRpcError: Decodable {
     let code: Int
     let message: String
-    let data: JsonRpcErrorData?
+    let data: String?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        code = try container.decode(Int.self, forKey: .code)
+        message = try container.decode(String.self, forKey: .message)
+
+        do {
+            let anyDecodable = try container.decode(AnyDecodable.self, forKey: .data)
+            let jsonData = try JSONSerialization.data(withJSONObject: anyDecodable.value)
+            data = String(data: jsonData, encoding: .utf8)
+        } catch {
+            data = nil
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case code
+        case message
+        case data
+    }
 }
 
 struct JsonRpcResponse<T: Decodable>: Decodable {
@@ -26,5 +38,28 @@ struct JsonRpcResponse<T: Decodable>: Decodable {
         case jsonRpc = "jsonrpc"
         case result
         case error
+    }
+}
+
+private struct AnyDecodable: Decodable {
+    let value: Any
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let stringValue = try? container.decode(String.self) {
+            value = stringValue
+        } else if let intValue = try? container.decode(Int.self) {
+            value = intValue
+        } else if let boolValue = try? container.decode(Bool.self) {
+            value = boolValue
+        } else if let doubleValue = try? container.decode(Double.self) {
+            value = doubleValue
+        } else if let arrayValue = try? container.decode([AnyDecodable].self) {
+            value = arrayValue.map(\.value)
+        } else if let dictionaryValue = try? container.decode([String: AnyDecodable].self) {
+            value = dictionaryValue.mapValues { $0.value }
+        } else {
+            throw DecodingError.typeMismatch(AnyDecodable.self, DecodingError.Context(codingPath: container.codingPath, debugDescription: "Unsupported type"))
+        }
     }
 }

--- a/Sources/Starknet/Providers/StarknetProvider/StarknetProvider.swift
+++ b/Sources/Starknet/Providers/StarknetProvider/StarknetProvider.swift
@@ -59,7 +59,7 @@ public class StarknetProvider: StarknetProviderProtocol {
         if let result = response.result {
             return result
         } else if let error = response.error {
-            throw StarknetProviderError.jsonRpcError(error.code, error.message, error.data?.revertError)
+            throw StarknetProviderError.jsonRpcError(error.code, error.message, error.data)
         } else {
             throw StarknetProviderError.unknownError
         }

--- a/Tests/StarknetTests/Data/JsonRpcResponseTests.swift
+++ b/Tests/StarknetTests/Data/JsonRpcResponseTests.swift
@@ -59,6 +59,11 @@ final class JsonRpcResponseTests: XCTestCase {
         XCTAssertNil(response.result)
         XCTAssertNotNil(response.error)
         XCTAssertNotNil(response.error!.data)
+        let data = response.error!.data!
+        XCTAssertTrue(data.contains("\"error\":\"Invalid message selector\""))
+        XCTAssertTrue(data.contains("\"details\""))
+        XCTAssertTrue(data.contains("\"selector\":\"0x1234\""))
+        XCTAssertTrue(data.contains("\"number\":123"))
     }
 
     func testErrorWithStringData() async throws {
@@ -80,6 +85,8 @@ final class JsonRpcResponseTests: XCTestCase {
         XCTAssertNil(response.result)
         XCTAssertNotNil(response.error)
         XCTAssertNotNil(response.error!.data)
+        let data = response.error!.data!
+        XCTAssertEqual(data, "More data about the execution failure.")
     }
 
     func testErrorWithSequenceData() async throws {
@@ -104,5 +111,7 @@ final class JsonRpcResponseTests: XCTestCase {
         XCTAssertNil(response.result)
         XCTAssertNotNil(response.error)
         XCTAssertNotNil(response.error!.data)
+        let data = response.error!.data!
+        XCTAssertEqual(data, "[\"More data about the execution failure.\",\"And even more data.\"]")
     }
 }

--- a/Tests/StarknetTests/Data/JsonRpcResponseTests.swift
+++ b/Tests/StarknetTests/Data/JsonRpcResponseTests.swift
@@ -16,7 +16,7 @@ final class JsonRpcResponseTests: XCTestCase {
         XCTAssertNoThrow(try decoder.decode(JsonRpcResponse<Int>.self, from: json))
     }
 
-    func testError() async throws {
+    func testErrorWithoutData() async throws {
         let json = """
         {
             "id": 0,
@@ -34,7 +34,34 @@ final class JsonRpcResponseTests: XCTestCase {
         XCTAssertNotNil(response.error)
     }
 
-    func testErrorWithData() async throws {
+    func testErrorWithObjectData() async throws {
+        let json = """
+        {
+            "id": 0,
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32603,
+                "message": "Internal error",
+                "data": {
+                    "error": "Invalid message selector",
+                    "details": {
+                        "selector": "0x1234",
+                        "number": 123
+                    }
+                }
+            }
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+
+        let response = try decoder.decode(JsonRpcResponse<Int>.self, from: json)
+        XCTAssertNil(response.result)
+        XCTAssertNotNil(response.error)
+        XCTAssertNotNil(response.error!.data)
+    }
+
+    func testErrorWithStringData() async throws {
         let json = """
         {
             "id": 0,
@@ -42,9 +69,31 @@ final class JsonRpcResponseTests: XCTestCase {
             "error": {
                 "code": 40,
                 "message": "Contract error",
-                "data": {
-                    "revert_error": "More data about the execution failure."
-                }
+                "data": "More data about the execution failure."
+            }
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+
+        let response = try decoder.decode(JsonRpcResponse<Int>.self, from: json)
+        XCTAssertNil(response.result)
+        XCTAssertNotNil(response.error)
+        XCTAssertNotNil(response.error!.data)
+    }
+
+    func testErrorWithSequenceData() async throws {
+        let json = """
+        {
+            "id": 0,
+            "jsonrpc": "2.0",
+            "error": {
+                "code": 40,
+                "message": "Contract error",
+                "data": [
+                    "More data about the execution failure.",
+                    "And even more data."
+                ]
             }
         }
         """.data(using: .utf8)!


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

Cherry-picked from #124 to support errors with any `data` in RPC 0.5.0-compatible version of starknet.swift 
  
  
- Remove `JsonRpcErrorData`
- `JsonRpcError.data` is now of type `String?` instead of `JsonRpcErrorData?`; convert any raw json to `String`

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
