### PR TITLE
Set chain ID in StarknetAccount initializer

### DIFF
--- a/Sources/Starknet/Accounts/StarknetAccount.swift
+++ b/Sources/Starknet/Accounts/StarknetAccount.swift
@@ -13,14 +13,16 @@ public enum CairoVersion: String, Encodable {
 public class StarknetAccount: StarknetAccountProtocol {
     private let cairoVersion: CairoVersion
     public let address: Felt
+    public let chainId: StarknetChainId
 
     private let signer: StarknetSignerProtocol
     private let provider: StarknetProviderProtocol
 
-    public init(address: Felt, signer: StarknetSignerProtocol, provider: StarknetProviderProtocol, cairoVersion: CairoVersion) {
+    public init(address: Felt, signer: StarknetSignerProtocol, provider: StarknetProviderProtocol, chainId: StarknetChainId, cairoVersion: CairoVersion) {
         self.address = address
         self.signer = signer
         self.provider = provider
+        self.chainId = chainId
         self.cairoVersion = cairoVersion
     }
 
@@ -45,7 +47,6 @@ public class StarknetAccount: StarknetAccountProtocol {
 
         let transaction = makeInvokeTransactionV1(calldata: calldata, signature: [], params: params, forFeeEstimation: forFeeEstimation)
 
-        let chainId = try await provider.getChainId()
         let hash = StarknetTransactionHashCalculator.computeHash(of: transaction, chainId: chainId)
 
         let signature = try signer.sign(transactionHash: hash)
@@ -58,7 +59,6 @@ public class StarknetAccount: StarknetAccountProtocol {
 
         let transaction = makeInvokeTransactionV3(calldata: calldata, signature: [], params: params, forFeeEstimation: forFeeEstimation)
 
-        let chainId = try await provider.getChainId()
         let hash = StarknetTransactionHashCalculator.computeHash(of: transaction, chainId: chainId)
 
         let signature = try signer.sign(transactionHash: hash)
@@ -69,7 +69,6 @@ public class StarknetAccount: StarknetAccountProtocol {
     public func signDeployAccountV1(classHash: Felt, calldata: StarknetCalldata, salt: Felt, params: StarknetDeployAccountParamsV1, forFeeEstimation: Bool) async throws -> StarknetDeployAccountTransactionV1 {
         let transaction = makeDeployAccountTransactionV1(classHash: classHash, salt: salt, calldata: calldata, signature: [], params: params, forFeeEstimation: forFeeEstimation)
 
-        let chainId = try await provider.getChainId()
         let hash = StarknetTransactionHashCalculator.computeHash(of: transaction, chainId: chainId)
 
         let signature = try signer.sign(transactionHash: hash)
@@ -80,7 +79,6 @@ public class StarknetAccount: StarknetAccountProtocol {
     public func signDeployAccountV3(classHash: Felt, calldata: StarknetCalldata, salt: Felt, params: StarknetDeployAccountParamsV3, forFeeEstimation: Bool) async throws -> StarknetDeployAccountTransactionV3 {
         let transaction = makeDeployAccountTransactionV3(classHash: classHash, salt: salt, calldata: calldata, signature: [], params: params, forFeeEstimation: forFeeEstimation)
 
-        let chainId = try await provider.getChainId()
         let hash = StarknetTransactionHashCalculator.computeHash(of: transaction, chainId: chainId)
 
         let signature = try signer.sign(transactionHash: hash)

--- a/Sources/Starknet/Accounts/StarknetAccountProtocol.swift
+++ b/Sources/Starknet/Accounts/StarknetAccountProtocol.swift
@@ -3,6 +3,8 @@ import Foundation
 public protocol StarknetAccountProtocol {
     /// Address of starknet account.
     var address: Felt { get }
+    /// Chain id of the Starknet provider.
+    var chainId: StarknetChainId { get }
 
     /// Sign list of calls as invoke transaction v1
     ///

--- a/Sources/Starknet/Data/StarknetChainId.swift
+++ b/Sources/Starknet/Data/StarknetChainId.swift
@@ -1,14 +1,27 @@
 import BigInt
 import Foundation
 
-public enum StarknetChainId: String, Codable, Equatable {
-    case mainnet = "0x534e5f4d41494e"
-    case goerli = "0x534e5f474f45524c49"
-    case sepolia = "0x534e5f5345504f4c4941"
-    case integration_sepolia = "0x534e5f494e544547524154494f4e5f5345504f4c4941"
+public struct StarknetChainId: Codable, Equatable {
+    public let value: Felt
 
-    public var feltValue: Felt {
-        Felt(fromHex: self.rawValue)!
+    public static let main = StarknetChainId(fromHex: "0x534e5f4d41494e")
+    public static let goerli = StarknetChainId(fromHex: "0x534e5f474f45524c49")
+    public static let sepolia = StarknetChainId(fromHex: "0x534e5f5345504f4c4941")
+    public static let integration_sepolia = StarknetChainId(fromHex: "0x534e5f494e544547524154494f4e5f5345504f4c4941")
+
+    public init(_ value: Felt) {
+        self.value = value
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+        self.value = Felt(fromHex: value)!
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.value)
     }
 
     enum CodingKeys: String, CodingKey {
@@ -16,5 +29,19 @@ public enum StarknetChainId: String, Codable, Equatable {
         case goerli = "0x534e5f474f45524c49"
         case sepolia = "0x534e5f5345504f4c4941"
         case integration_sepolia = "0x534e5f494e544547524154494f4e5f5345504f4c4941"
+    }
+}
+
+public extension StarknetChainId {
+    init(fromHex hex: String) {
+        self.value = Felt(fromHex: hex)!
+    }
+
+    init(fromNetworkName networkName: String) {
+        self.value = Felt.fromShortString(networkName)!
+    }
+
+    func toNetworkName() -> String {
+        self.value.toShortString()
     }
 }

--- a/Sources/Starknet/Data/StarknetChainId.swift
+++ b/Sources/Starknet/Data/StarknetChainId.swift
@@ -1,0 +1,20 @@
+import BigInt
+import Foundation
+
+public enum StarknetChainId: String, Codable, Equatable {
+    case mainnet = "0x534e5f4d41494e"
+    case goerli = "0x534e5f474f45524c49"
+    case sepolia = "0x534e5f5345504f4c4941"
+    case integration_sepolia = "0x534e5f494e544547524154494f4e5f5345504f4c4941"
+
+    public var feltValue: Felt {
+        Felt(fromHex: self.rawValue)!
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case mainnet = "0x534e5f4d41494e"
+        case goerli = "0x534e5f474f45524c49"
+        case sepolia = "0x534e5f5345504f4c4941"
+        case integration_sepolia = "0x534e5f494e544547524154494f4e5f5345504f4c4941"
+    }
+}

--- a/Sources/Starknet/Data/Transaction/TransactionHash.swift
+++ b/Sources/Starknet/Data/Transaction/TransactionHash.swift
@@ -11,7 +11,7 @@ public class StarknetTransactionHashCalculator {
         entryPointSelector: Felt,
         calldata: StarknetCalldata,
         maxFee: Felt,
-        chainId: Felt,
+        chainId: StarknetChainId,
         nonce: Felt
     ) -> Felt {
         StarknetCurve.pedersenOn(
@@ -21,12 +21,12 @@ public class StarknetTransactionHashCalculator {
             entryPointSelector,
             StarknetCurve.pedersenOn(calldata),
             maxFee,
-            chainId,
+            chainId.feltValue,
             nonce
         )
     }
 
-    private class func prepareCommonTransactionV3Fields(of transaction: any StarknetTransactionV3, address: Felt, chainId: Felt) -> [Felt] {
+    private class func prepareCommonTransactionV3Fields(of transaction: any StarknetTransactionV3, address: Felt, chainId: StarknetChainId) -> [Felt] {
         let transactionType = transaction.type
         let version = transaction.version
         let tip = transaction.tip
@@ -45,7 +45,7 @@ public class StarknetTransactionHashCalculator {
                     + StarknetTransactionHashCalculator.resourceBoundsForFee(resourceBounds)
             ),
             StarknetPoseidon.poseidonHash(paymasterData),
-            chainId,
+            chainId.feltValue,
             nonce,
             StarknetTransactionHashCalculator.dataAvailabilityModes(
                 feeDataAvailabilityMode: feeDataAvailabilityMode,
@@ -54,7 +54,7 @@ public class StarknetTransactionHashCalculator {
         ]
     }
 
-    public class func computeHash(of transaction: StarknetInvokeTransactionV1, chainId: Felt) -> Felt {
+    public class func computeHash(of transaction: StarknetInvokeTransactionV1, chainId: StarknetChainId) -> Felt {
         computeCommonDeprecatedTransactionHash(
             transactionType: transaction.type,
             version: transaction.version,
@@ -67,7 +67,7 @@ public class StarknetTransactionHashCalculator {
         )
     }
 
-    public class func computeHash(of transaction: StarknetInvokeTransactionV3, chainId: Felt) -> Felt {
+    public class func computeHash(of transaction: StarknetInvokeTransactionV3, chainId: StarknetChainId) -> Felt {
         let commonFields = StarknetTransactionHashCalculator.prepareCommonTransactionV3Fields(
             of: transaction,
             address: transaction.senderAddress,
@@ -81,7 +81,7 @@ public class StarknetTransactionHashCalculator {
         )
     }
 
-    public class func computeHash(of transaction: StarknetDeployAccountTransactionV1, chainId: Felt) -> Felt {
+    public class func computeHash(of transaction: StarknetDeployAccountTransactionV1, chainId: StarknetChainId) -> Felt {
         let contractAddress = StarknetContractAddressCalculator.calculateFrom(
             classHash: transaction.classHash,
             calldata: transaction.constructorCalldata,
@@ -102,7 +102,7 @@ public class StarknetTransactionHashCalculator {
         )
     }
 
-    public class func computeHash(of transaction: StarknetDeployAccountTransactionV3, chainId: Felt) -> Felt {
+    public class func computeHash(of transaction: StarknetDeployAccountTransactionV3, chainId: StarknetChainId) -> Felt {
         let contractAddress = StarknetContractAddressCalculator.calculateFrom(
             classHash: transaction.classHash,
             calldata: transaction.constructorCalldata,

--- a/Sources/Starknet/Data/Transaction/TransactionHash.swift
+++ b/Sources/Starknet/Data/Transaction/TransactionHash.swift
@@ -21,7 +21,7 @@ public class StarknetTransactionHashCalculator {
             entryPointSelector,
             StarknetCurve.pedersenOn(calldata),
             maxFee,
-            chainId.feltValue,
+            chainId.value,
             nonce
         )
     }
@@ -45,7 +45,7 @@ public class StarknetTransactionHashCalculator {
                     + StarknetTransactionHashCalculator.resourceBoundsForFee(resourceBounds)
             ),
             StarknetPoseidon.poseidonHash(paymasterData),
-            chainId.feltValue,
+            chainId.value,
             nonce,
             StarknetTransactionHashCalculator.dataAvailabilityModes(
                 feeDataAvailabilityMode: feeDataAvailabilityMode,

--- a/Sources/Starknet/Providers/StarknetProvider/StarknetProvider.swift
+++ b/Sources/Starknet/Providers/StarknetProvider/StarknetProvider.swift
@@ -178,10 +178,10 @@ public class StarknetProvider: StarknetProviderProtocol {
         return result
     }
 
-    public func getChainId() async throws -> Felt {
+    public func getChainId() async throws -> StarknetChainId {
         let params = EmptySequence()
 
-        let result = try await makeRequest(method: .getChainId, params: params, receive: Felt.self)
+        let result = try await makeRequest(method: .getChainId, params: params, receive: StarknetChainId.self)
 
         return result
     }

--- a/Sources/Starknet/Providers/StarknetProviderProtocol.swift
+++ b/Sources/Starknet/Providers/StarknetProviderProtocol.swift
@@ -127,7 +127,7 @@ public protocol StarknetProviderProtocol {
     /// Get the currently configured Starknet chain id
     ///
     /// - Returns: The Starknet chain id
-    func getChainId() async throws -> Felt
+    func getChainId() async throws -> StarknetChainId
 
     /// Simulate running a given list of transactions, and generate the execution trace
     ///

--- a/Tests/StarknetTests/Accounts/AccountTest.swift
+++ b/Tests/StarknetTests/Accounts/AccountTest.swift
@@ -6,6 +6,7 @@ final class AccountTests: XCTestCase {
     static var devnetClient: DevnetClientProtocol!
 
     var provider: StarknetProviderProtocol!
+    var chainId: StarknetChainId!
     var signer: StarknetSignerProtocol!
     var account: StarknetAccountProtocol!
     var accountContractClassHash: Felt!
@@ -23,7 +24,7 @@ final class AccountTests: XCTestCase {
         ethContractAddress = Self.devnetClient.constants.ethErc20ContractAddress
         let accountDetails = Self.devnetClient.constants.predeployedAccount1
         signer = StarkCurveSigner(privateKey: accountDetails.privateKey)!
-        account = StarknetAccount(address: accountDetails.address, signer: signer, provider: provider, cairoVersion: .zero)
+        account = StarknetAccount(address: accountDetails.address, signer: signer, provider: provider, chainId: chainId, cairoVersion: .zero)
     }
 
     override class func setUp() {
@@ -146,7 +147,7 @@ final class AccountTests: XCTestCase {
         let newSigner = StarkCurveSigner(privateKey: 1234)!
         let newPublicKey = newSigner.publicKey
         let newAccountAddress = StarknetContractAddressCalculator.calculateFrom(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero)
-        let newAccount = StarknetAccount(address: newAccountAddress, signer: newSigner, provider: provider, cairoVersion: .zero)
+        let newAccount = StarknetAccount(address: newAccountAddress, signer: newSigner, provider: provider, chainId: chainId, cairoVersion: .zero)
 
         try await Self.devnetClient.prefundAccount(address: newAccountAddress)
 
@@ -172,7 +173,7 @@ final class AccountTests: XCTestCase {
         let newSigner = StarkCurveSigner(privateKey: 4567)!
         let newPublicKey = newSigner.publicKey
         let newAccountAddress = StarknetContractAddressCalculator.calculateFrom(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero)
-        let newAccount = StarknetAccount(address: newAccountAddress, signer: newSigner, provider: provider, cairoVersion: .zero)
+        let newAccount = StarknetAccount(address: newAccountAddress, signer: newSigner, provider: provider, chainId: chainId, cairoVersion: .zero)
 
         try await Self.devnetClient.prefundAccount(address: newAccountAddress, unit: .fri)
 

--- a/Tests/StarknetTests/Accounts/AccountTest.swift
+++ b/Tests/StarknetTests/Accounts/AccountTest.swift
@@ -24,6 +24,7 @@ final class AccountTests: XCTestCase {
         ethContractAddress = Self.devnetClient.constants.ethErc20ContractAddress
         let accountDetails = Self.devnetClient.constants.predeployedAccount1
         signer = StarkCurveSigner(privateKey: accountDetails.privateKey)!
+        chainId = try await provider.getChainId()
         account = StarknetAccount(address: accountDetails.address, signer: signer, provider: provider, chainId: chainId, cairoVersion: .zero)
     }
 

--- a/Tests/StarknetTests/Data/ExecutionTests.swift
+++ b/Tests/StarknetTests/Data/ExecutionTests.swift
@@ -20,7 +20,8 @@ final class ExecutionTests: XCTestCase {
         provider = StarknetProvider(url: Self.devnetClient.rpcUrl)!
         let accountDetails = ExecutionTests.devnetClient.constants.predeployedAccount1
         signer = StarkCurveSigner(privateKey: accountDetails.privateKey)!
-        account = StarknetAccount(address: accountDetails.address, signer: signer, provider: provider, cairoVersion: .one)
+        let chainId = try await provider.getChainId()
+        account = StarknetAccount(address: accountDetails.address, signer: signer, provider: provider, chainId: chainId, cairoVersion: .one)
         balanceContractAddress = try await Self.devnetClient.declareDeployContract(contractName: "Balance").deploy.contractAddress
     }
 

--- a/Tests/StarknetTests/Data/StarknetChainIdTests.swift
+++ b/Tests/StarknetTests/Data/StarknetChainIdTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+
+@testable import Starknet
+
+final class StarknetChainIdTests: XCTestCase {
+    static var chainIdCases: [(StarknetChainId, String, String)] = []
+
+    override class func setUp() {
+        self.chainIdCases = [
+            (StarknetChainId.main, "SN_MAIN", "0x534e5f4d41494e"),
+            (StarknetChainId.goerli, "SN_GOERLI", "0x534e5f474f45524c49"),
+            (StarknetChainId.sepolia, "SN_SEPOLIA", "0x534e5f5345504f4c4941"),
+            (StarknetChainId.integration_sepolia, "SN_INTEGRATION_SEPOLIA", "0x534e5f494e544547524154494f4e5f5345504f4c4941"),
+        ]
+    }
+
+    func testFromHexInitializer() {
+        for (chainId, _, hex) in Self.chainIdCases {
+            XCTAssertEqual(StarknetChainId(fromHex: hex), chainId)
+        }
+    }
+
+    func testFromNetworkNameInitializer() {
+        for (chainId, name, _) in Self.chainIdCases {
+            XCTAssertEqual(StarknetChainId(fromNetworkName: name), chainId)
+        }
+    }
+
+    func testToNetworkName() {
+        for (chainId, name, _) in Self.chainIdCases {
+            XCTAssertEqual(chainId.toNetworkName(), name)
+        }
+    }
+
+    func testEncoding() {
+        for (chainId, _, hexString) in Self.chainIdCases {
+            do {
+                let data = try JSONEncoder().encode(chainId)
+                let expectedData = Data("\"\(hexString)\"".utf8)
+                XCTAssertEqual(data, expectedData)
+            } catch {
+                XCTFail("Failed to encode \(chainId)")
+            }
+        }
+    }
+
+    func testDecoding() {
+        for (chainId, _, hexString) in Self.chainIdCases {
+            do {
+                let data = Data("\"\(hexString)\"".utf8)
+                let decoded = try JSONDecoder().decode(StarknetChainId.self, from: data)
+                XCTAssertEqual(decoded, chainId)
+            } catch {
+                XCTFail("Failed to decode \(chainId)")
+            }
+        }
+    }
+
+    func testCustomChainId() {
+        let chainIdFromHex = StarknetChainId(fromHex: "0x4b4154414e41")
+        let chainIdFromNetworkName = StarknetChainId(fromNetworkName: "KATANA")
+        XCTAssertEqual(chainIdFromHex, chainIdFromNetworkName)
+    }
+}

--- a/Tests/StarknetTests/Providers/ProviderTests.swift
+++ b/Tests/StarknetTests/Providers/ProviderTests.swift
@@ -34,7 +34,7 @@ final class ProviderTests: XCTestCase {
         accountContractClassHash = Self.devnetClient.constants.accountContractClassHash
         let accountDetails = Self.devnetClient.constants.predeployedAccount2
         signer = StarkCurveSigner(privateKey: accountDetails.privateKey)!
-        
+
         chainId = try await provider.getChainId()
         account = StarknetAccount(address: accountDetails.address, signer: signer, provider: provider, chainId: chainId, cairoVersion: .zero)
     }

--- a/Tests/StarknetTests/Providers/ProviderTests.swift
+++ b/Tests/StarknetTests/Providers/ProviderTests.swift
@@ -6,6 +6,7 @@ final class ProviderTests: XCTestCase {
     static var devnetClient: DevnetClientProtocol!
 
     var provider: StarknetProviderProtocol!
+    var chainId: StarknetChainId!
     var signer: StarknetSignerProtocol!
     var account: StarknetAccountProtocol!
     var accountContractClassHash: Felt!
@@ -33,7 +34,9 @@ final class ProviderTests: XCTestCase {
         accountContractClassHash = Self.devnetClient.constants.accountContractClassHash
         let accountDetails = Self.devnetClient.constants.predeployedAccount2
         signer = StarkCurveSigner(privateKey: accountDetails.privateKey)!
-        account = StarknetAccount(address: accountDetails.address, signer: signer, provider: provider, cairoVersion: .zero)
+        
+        chainId = try await provider.getChainId()
+        account = StarknetAccount(address: accountDetails.address, signer: signer, provider: provider, chainId: chainId, cairoVersion: .zero)
     }
 
     func makeStarknetProvider(url: String) -> StarknetProviderProtocol {
@@ -246,7 +249,7 @@ final class ProviderTests: XCTestCase {
         let newSigner = StarkCurveSigner(privateKey: 1111)!
         let newPublicKey = newSigner.publicKey
         let newAccountAddress = StarknetContractAddressCalculator.calculateFrom(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero)
-        let newAccount = StarknetAccount(address: newAccountAddress, signer: newSigner, provider: provider, cairoVersion: .zero)
+        let newAccount = StarknetAccount(address: newAccountAddress, signer: newSigner, provider: provider, chainId: chainId, cairoVersion: .zero)
 
         try await Self.devnetClient.prefundAccount(address: newAccountAddress)
 
@@ -267,7 +270,7 @@ final class ProviderTests: XCTestCase {
         let newSigner = StarkCurveSigner(privateKey: 3333)!
         let newPublicKey = newSigner.publicKey
         let newAccountAddress = StarknetContractAddressCalculator.calculateFrom(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero)
-        let newAccount = StarknetAccount(address: newAccountAddress, signer: newSigner, provider: provider, cairoVersion: .zero)
+        let newAccount = StarknetAccount(address: newAccountAddress, signer: newSigner, provider: provider, chainId: chainId, cairoVersion: .zero)
 
         try await Self.devnetClient.prefundAccount(address: newAccountAddress)
 
@@ -322,7 +325,7 @@ final class ProviderTests: XCTestCase {
         let newSigner = StarkCurveSigner(privateKey: 1001)!
         let newPublicKey = newSigner.publicKey
         let newAccountAddress = StarknetContractAddressCalculator.calculateFrom(classHash: accountClassHash, calldata: [newPublicKey], salt: .zero)
-        let newAccount = StarknetAccount(address: newAccountAddress, signer: newSigner, provider: provider, cairoVersion: .zero)
+        let newAccount = StarknetAccount(address: newAccountAddress, signer: newSigner, provider: provider, chainId: chainId, cairoVersion: .zero)
 
         try await Self.devnetClient.prefundAccount(address: newAccountAddress)
 
@@ -363,7 +366,7 @@ final class ProviderTests: XCTestCase {
         let newSigner = StarkCurveSigner(privateKey: 3003)!
         let newPublicKey = newSigner.publicKey
         let newAccountAddress = StarknetContractAddressCalculator.calculateFrom(classHash: accountClassHash, calldata: [newPublicKey], salt: .zero)
-        let newAccount = StarknetAccount(address: newAccountAddress, signer: newSigner, provider: provider, cairoVersion: .zero)
+        let newAccount = StarknetAccount(address: newAccountAddress, signer: newSigner, provider: provider, chainId: chainId, cairoVersion: .zero)
 
         try await Self.devnetClient.prefundAccount(address: newAccountAddress, amount: 5_000_000_000_000_000_000, unit: .fri)
 

--- a/Tests/StarknetTests/Providers/ProviderTests.swift
+++ b/Tests/StarknetTests/Providers/ProviderTests.swift
@@ -51,7 +51,7 @@ final class ProviderTests: XCTestCase {
     func testGetChainId() async throws {
         let chainId = try await provider.getChainId()
 
-        XCTAssertEqual(chainId.toShortString(), "SN_GOERLI")
+        XCTAssertEqual(chainId, .goerli)
     }
 
     func testSpecVersion() async throws {


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #153

## Breaking changes

- [x] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
-  `StarknetAccount` constructor now has a mandatory `chainId` argument
- `StarknetAccountProtocol` now has `chainId: StarknetChainId` property

