### PR TITLE
Change signing methods which are no longer async

### DIFF
--- a/Sources/Starknet/Accounts/StarknetAccount.swift
+++ b/Sources/Starknet/Accounts/StarknetAccount.swift
@@ -42,7 +42,7 @@ public class StarknetAccount: StarknetAccountProtocol {
         StarknetDeployAccountTransactionV3(signature: signature, l1ResourceBounds: params.resourceBounds.l1Gas, nonce: params.nonce, contractAddressSalt: salt, constructorCalldata: calldata, classHash: classHash, forFeeEstimation: forFeeEstimation)
     }
 
-    public func signV1(calls: [StarknetCall], params: StarknetInvokeParamsV1, forFeeEstimation: Bool) async throws -> StarknetInvokeTransactionV1 {
+    public func signV1(calls: [StarknetCall], params: StarknetInvokeParamsV1, forFeeEstimation: Bool) throws -> StarknetInvokeTransactionV1 {
         let calldata = starknetCallsToExecuteCalldata(calls: calls, cairoVersion: cairoVersion)
 
         let transaction = makeInvokeTransactionV1(calldata: calldata, signature: [], params: params, forFeeEstimation: forFeeEstimation)
@@ -54,7 +54,7 @@ public class StarknetAccount: StarknetAccountProtocol {
         return makeInvokeTransactionV1(calldata: calldata, signature: signature, params: params, forFeeEstimation: forFeeEstimation)
     }
 
-    public func signV3(calls: [StarknetCall], params: StarknetInvokeParamsV3, forFeeEstimation: Bool) async throws -> StarknetInvokeTransactionV3 {
+    public func signV3(calls: [StarknetCall], params: StarknetInvokeParamsV3, forFeeEstimation: Bool) throws -> StarknetInvokeTransactionV3 {
         let calldata = starknetCallsToExecuteCalldata(calls: calls, cairoVersion: cairoVersion)
 
         let transaction = makeInvokeTransactionV3(calldata: calldata, signature: [], params: params, forFeeEstimation: forFeeEstimation)
@@ -66,7 +66,7 @@ public class StarknetAccount: StarknetAccountProtocol {
         return makeInvokeTransactionV3(calldata: calldata, signature: signature, params: params, forFeeEstimation: forFeeEstimation)
     }
 
-    public func signDeployAccountV1(classHash: Felt, calldata: StarknetCalldata, salt: Felt, params: StarknetDeployAccountParamsV1, forFeeEstimation: Bool) async throws -> StarknetDeployAccountTransactionV1 {
+    public func signDeployAccountV1(classHash: Felt, calldata: StarknetCalldata, salt: Felt, params: StarknetDeployAccountParamsV1, forFeeEstimation: Bool) throws -> StarknetDeployAccountTransactionV1 {
         let transaction = makeDeployAccountTransactionV1(classHash: classHash, salt: salt, calldata: calldata, signature: [], params: params, forFeeEstimation: forFeeEstimation)
 
         let hash = StarknetTransactionHashCalculator.computeHash(of: transaction, chainId: chainId)
@@ -76,7 +76,7 @@ public class StarknetAccount: StarknetAccountProtocol {
         return makeDeployAccountTransactionV1(classHash: classHash, salt: salt, calldata: calldata, signature: signature, params: params, forFeeEstimation: forFeeEstimation)
     }
 
-    public func signDeployAccountV3(classHash: Felt, calldata: StarknetCalldata, salt: Felt, params: StarknetDeployAccountParamsV3, forFeeEstimation: Bool) async throws -> StarknetDeployAccountTransactionV3 {
+    public func signDeployAccountV3(classHash: Felt, calldata: StarknetCalldata, salt: Felt, params: StarknetDeployAccountParamsV3, forFeeEstimation: Bool) throws -> StarknetDeployAccountTransactionV3 {
         let transaction = makeDeployAccountTransactionV3(classHash: classHash, salt: salt, calldata: calldata, signature: [], params: params, forFeeEstimation: forFeeEstimation)
 
         let hash = StarknetTransactionHashCalculator.computeHash(of: transaction, chainId: chainId)
@@ -104,7 +104,7 @@ public class StarknetAccount: StarknetAccountProtocol {
         }
 
         let params = StarknetInvokeParamsV1(nonce: nonce, maxFee: maxFee)
-        let signedTransaction = try await signV1(calls: calls, params: params, forFeeEstimation: false)
+        let signedTransaction = try signV1(calls: calls, params: params, forFeeEstimation: false)
 
         return try await provider.addInvokeTransaction(signedTransaction)
     }
@@ -127,35 +127,35 @@ public class StarknetAccount: StarknetAccountProtocol {
         }
 
         let params = StarknetInvokeParamsV3(nonce: nonce, l1ResourceBounds: resourceBounds.l1Gas)
-        let signedTransaction = try await signV3(calls: calls, params: params, forFeeEstimation: false)
+        let signedTransaction = try signV3(calls: calls, params: params, forFeeEstimation: false)
 
         return try await provider.addInvokeTransaction(signedTransaction)
     }
 
     public func estimateFeeV1(calls: [StarknetCall], nonce: Felt, skipValidate: Bool) async throws -> StarknetFeeEstimate {
         let params = StarknetInvokeParamsV1(nonce: nonce, maxFee: .zero)
-        let signedTransaction = try await signV1(calls: calls, params: params, forFeeEstimation: true)
+        let signedTransaction = try signV1(calls: calls, params: params, forFeeEstimation: true)
 
         return try await provider.estimateFee(for: signedTransaction, simulationFlags: skipValidate ? [.skipValidate] : [])
     }
 
     public func estimateFeeV3(calls: [StarknetCall], nonce: Felt, skipValidate: Bool) async throws -> StarknetFeeEstimate {
         let params = StarknetInvokeParamsV3(nonce: nonce, l1ResourceBounds: .zero)
-        let signedTransaction = try await signV3(calls: calls, params: params, forFeeEstimation: true)
+        let signedTransaction = try signV3(calls: calls, params: params, forFeeEstimation: true)
 
         return try await provider.estimateFee(for: signedTransaction, simulationFlags: skipValidate ? [.skipValidate] : [])
     }
 
     public func estimateDeployAccountFeeV1(classHash: Felt, calldata: StarknetCalldata, salt: Felt, nonce: Felt, skipValidate: Bool) async throws -> StarknetFeeEstimate {
         let params = StarknetDeployAccountParamsV1(nonce: nonce, maxFee: 0)
-        let signedTransaction = try await signDeployAccountV1(classHash: classHash, calldata: calldata, salt: salt, params: params, forFeeEstimation: true)
+        let signedTransaction = try signDeployAccountV1(classHash: classHash, calldata: calldata, salt: salt, params: params, forFeeEstimation: true)
 
         return try await provider.estimateFee(for: signedTransaction, simulationFlags: skipValidate ? [.skipValidate] : [])
     }
 
     public func estimateDeployAccountFeeV3(classHash: Felt, calldata: StarknetCalldata, salt: Felt, nonce: Felt, skipValidate: Bool) async throws -> StarknetFeeEstimate {
         let params = StarknetDeployAccountParamsV3(nonce: nonce, l1ResourceBounds: .zero)
-        let signedTransaction = try await signDeployAccountV3(classHash: classHash, calldata: calldata, salt: salt, params: params, forFeeEstimation: true)
+        let signedTransaction = try signDeployAccountV3(classHash: classHash, calldata: calldata, salt: salt, params: params, forFeeEstimation: true)
 
         return try await provider.estimateFee(for: signedTransaction, simulationFlags: skipValidate ? [.skipValidate] : [])
     }

--- a/Sources/Starknet/Accounts/StarknetAccountProtocol.swift
+++ b/Sources/Starknet/Accounts/StarknetAccountProtocol.swift
@@ -14,7 +14,7 @@ public protocol StarknetAccountProtocol {
     ///  - forFeeEstimation: Flag indicating whether the different version of transaction should be used; such transaction can only be used for fee estimation
     ///
     /// - Returns: Signed invoke v1 transaction
-    func signV1(calls: [StarknetCall], params: StarknetInvokeParamsV1, forFeeEstimation: Bool) async throws -> StarknetInvokeTransactionV1
+    func signV1(calls: [StarknetCall], params: StarknetInvokeParamsV1, forFeeEstimation: Bool) throws -> StarknetInvokeTransactionV1
 
     /// Sign list of calls as invoke transaction v3
     ///
@@ -24,7 +24,7 @@ public protocol StarknetAccountProtocol {
     ///  - forFeeEstimation: Flag indicating whether the different version of transaction should be used; such transaction can only be used for fee estimation
     ///
     /// - Returns: Signed invoke v3 transaction
-    func signV3(calls: [StarknetCall], params: StarknetInvokeParamsV3, forFeeEstimation: Bool) async throws -> StarknetInvokeTransactionV3
+    func signV3(calls: [StarknetCall], params: StarknetInvokeParamsV3, forFeeEstimation: Bool) throws -> StarknetInvokeTransactionV3
 
     /// Create and sign deploy account transaction v1
     ///
@@ -36,7 +36,7 @@ public protocol StarknetAccountProtocol {
     ///  - forFeeEstimation: Flag indicating whether the different version of transaction should be used; such transaction can only be used for fee estimation
     ///
     /// - Returns: Signed deploy account transaction v1
-    func signDeployAccountV1(classHash: Felt, calldata: StarknetCalldata, salt: Felt, params: StarknetDeployAccountParamsV1, forFeeEstimation: Bool) async throws -> StarknetDeployAccountTransactionV1
+    func signDeployAccountV1(classHash: Felt, calldata: StarknetCalldata, salt: Felt, params: StarknetDeployAccountParamsV1, forFeeEstimation: Bool) throws -> StarknetDeployAccountTransactionV1
 
     /// Create and sign deploy account transaction v3
     ///
@@ -48,7 +48,7 @@ public protocol StarknetAccountProtocol {
     ///  - forFeeEstimation: Flag indicating whether the different version of transaction should be used; such transaction can only be used for fee estimation
     ///
     /// - Returns: Signed deploy account transaction v3
-    func signDeployAccountV3(classHash: Felt, calldata: StarknetCalldata, salt: Felt, params: StarknetDeployAccountParamsV3, forFeeEstimation: Bool) async throws -> StarknetDeployAccountTransactionV3
+    func signDeployAccountV3(classHash: Felt, calldata: StarknetCalldata, salt: Felt, params: StarknetDeployAccountParamsV3, forFeeEstimation: Bool) throws -> StarknetDeployAccountTransactionV3
 
     /// Sign TypedData for off-chain usage with this account's privateKey.
     ///
@@ -56,7 +56,7 @@ public protocol StarknetAccountProtocol {
     ///  - typedData: a TypedData object to sign
     ///
     /// - Returns: a signature for provided TypedData object.
-    func sign(typedData: StarknetTypedData) async throws -> StarknetSignature
+    func sign(typedData: StarknetTypedData) throws -> StarknetSignature
 
     /// Verify a signature of TypedData on Starknet.
     ///
@@ -160,8 +160,8 @@ public extension StarknetAccountProtocol {
     ///  - params: additional params for a given transaction
     ///
     /// - Returns: Signed invoke transaction v1
-    func signV1(calls: [StarknetCall], params: StarknetInvokeParamsV1) async throws -> StarknetInvokeTransactionV1 {
-        try await signV1(calls: calls, params: params, forFeeEstimation: false)
+    func signV1(calls: [StarknetCall], params: StarknetInvokeParamsV1) throws -> StarknetInvokeTransactionV1 {
+        try signV1(calls: calls, params: params, forFeeEstimation: false)
     }
 
     /// Sign list of calls for execution as invoke transaction v3.
@@ -172,8 +172,8 @@ public extension StarknetAccountProtocol {
     ///  - params: additional params for a given transaction
     ///
     /// - Returns: Signed invoke transaction v3
-    func signV3(calls: [StarknetCall], params: StarknetInvokeParamsV3) async throws -> StarknetInvokeTransactionV3 {
-        try await signV3(calls: calls, params: params, forFeeEstimation: false)
+    func signV3(calls: [StarknetCall], params: StarknetInvokeParamsV3) throws -> StarknetInvokeTransactionV3 {
+        try signV3(calls: calls, params: params, forFeeEstimation: false)
     }
 
     /// Create and sign deploy account transaction v1
@@ -186,8 +186,8 @@ public extension StarknetAccountProtocol {
     ///  - maxFee: max acceptable fee for the transaction
     ///
     /// - Returns: Signed deploy account transaction v1
-    func signDeployAccountV1(classHash: Felt, calldata: StarknetCalldata, salt: Felt, maxFee: Felt) async throws -> StarknetDeployAccountTransactionV1 {
-        try await signDeployAccountV1(classHash: classHash, calldata: calldata, salt: salt, params: StarknetDeployAccountParamsV1(nonce: .zero, maxFee: maxFee), forFeeEstimation: false)
+    func signDeployAccountV1(classHash: Felt, calldata: StarknetCalldata, salt: Felt, maxFee: Felt) throws -> StarknetDeployAccountTransactionV1 {
+        try signDeployAccountV1(classHash: classHash, calldata: calldata, salt: salt, params: StarknetDeployAccountParamsV1(nonce: .zero, maxFee: maxFee), forFeeEstimation: false)
     }
 
     /// Create and sign deploy account transaction v3
@@ -200,8 +200,8 @@ public extension StarknetAccountProtocol {
     ///  - l1ResourceBounds: max acceptable l1 resource bounds
     ///
     /// - Returns: Signed deploy account transaction v3
-    func signDeployAccountV3(classHash: Felt, calldata: StarknetCalldata, salt: Felt, l1ResourceBounds: StarknetResourceBounds) async throws -> StarknetDeployAccountTransactionV3 {
-        try await signDeployAccountV3(classHash: classHash, calldata: calldata, salt: salt, params: StarknetDeployAccountParamsV3(nonce: .zero, l1ResourceBounds: l1ResourceBounds), forFeeEstimation: false)
+    func signDeployAccountV3(classHash: Felt, calldata: StarknetCalldata, salt: Felt, l1ResourceBounds: StarknetResourceBounds) throws -> StarknetDeployAccountTransactionV3 {
+        try signDeployAccountV3(classHash: classHash, calldata: calldata, salt: salt, params: StarknetDeployAccountParamsV3(nonce: .zero, l1ResourceBounds: l1ResourceBounds), forFeeEstimation: false)
     }
 
     /// Sign a call as invoke transaction v1
@@ -213,7 +213,7 @@ public extension StarknetAccountProtocol {
     ///
     /// - Returns: Signed invoke transaction v1
     func signV1(call: StarknetCall, params: StarknetInvokeParamsV1, forFeeEstimation: Bool = false) async throws -> StarknetInvokeTransactionV1 {
-        try await signV1(calls: [call], params: params, forFeeEstimation: forFeeEstimation)
+        try signV1(calls: [call], params: params, forFeeEstimation: forFeeEstimation)
     }
 
     /// Sign a call as invoke transaction v3
@@ -223,8 +223,8 @@ public extension StarknetAccountProtocol {
     ///  - forFeeEstimation: Flag indicating whether the different version of transaction should be used; such transaction can only be used for fee estimation
     ///
     /// - Returns: Signed invoke transaction v3
-    func signV3(call: StarknetCall, params: StarknetInvokeParamsV3, forFeeEstimation: Bool = false) async throws -> StarknetInvokeTransactionV3 {
-        try await signV3(calls: [call], params: params, forFeeEstimation: forFeeEstimation)
+    func signV3(call: StarknetCall, params: StarknetInvokeParamsV3, forFeeEstimation: Bool = false) throws -> StarknetInvokeTransactionV3 {
+        try signV3(calls: [call], params: params, forFeeEstimation: forFeeEstimation)
     }
 
     /// Execute list of calls as invoke transaction v1

--- a/Tests/StarknetTests/Accounts/AccountTest.swift
+++ b/Tests/StarknetTests/Accounts/AccountTest.swift
@@ -159,7 +159,7 @@ final class AccountTests: XCTestCase {
 
         let params = StarknetDeployAccountParamsV1(nonce: nonce, maxFee: maxFee)
 
-        let deployAccountTransaction = try await newAccount.signDeployAccountV1(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero, params: params, forFeeEstimation: false)
+        let deployAccountTransaction = try newAccount.signDeployAccountV1(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero, params: params, forFeeEstimation: false)
 
         let response = try await provider.addDeployAccountTransaction(deployAccountTransaction)
 
@@ -184,7 +184,7 @@ final class AccountTests: XCTestCase {
 
         let params = StarknetDeployAccountParamsV3(nonce: nonce, l1ResourceBounds: feeEstimate.toResourceBounds().l1Gas)
 
-        let deployAccountTransaction = try await newAccount.signDeployAccountV3(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero, params: params, forFeeEstimation: false)
+        let deployAccountTransaction = try newAccount.signDeployAccountV3(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero, params: params, forFeeEstimation: false)
 
         let response = try await provider.addDeployAccountTransaction(deployAccountTransaction)
 
@@ -198,7 +198,7 @@ final class AccountTests: XCTestCase {
     func testSignTypedData() async throws {
         let typedData = loadTypedDataFromFile(name: "typed_data_struct_array_example")!
 
-        let signature = try await account.sign(typedData: typedData)
+        let signature = try account.sign(typedData: typedData)
         XCTAssertTrue(signature.count > 0)
 
         let successResult = try await account.verify(signature: signature, for: typedData)

--- a/Tests/StarknetTests/Data/ExecutionTests.swift
+++ b/Tests/StarknetTests/Data/ExecutionTests.swift
@@ -58,7 +58,7 @@ final class ExecutionTests: XCTestCase {
         )
         let params = StarknetInvokeParamsV1(nonce: .zero, maxFee: .zero)
 
-        let signedTx = try await account.signV1(calls: [call1, call2, call3], params: params)
+        let signedTx = try account.signV1(calls: [call1, call2, call3], params: params)
         let expectedCalldata = [
             Felt(3),
             balanceContractAddress,
@@ -79,7 +79,7 @@ final class ExecutionTests: XCTestCase {
 
         XCTAssertEqual(expectedCalldata, signedTx.calldata)
 
-        let signedEmptyTx = try await account.signV1(calls: [], params: params)
+        let signedEmptyTx = try account.signV1(calls: [], params: params)
 
         XCTAssertEqual([.zero], signedEmptyTx.calldata)
     }

--- a/Tests/StarknetTests/Providers/ProviderTests.swift
+++ b/Tests/StarknetTests/Providers/ProviderTests.swift
@@ -211,10 +211,10 @@ final class ProviderTests: XCTestCase {
         let call2 = StarknetCall(contractAddress: contractAddress, entrypoint: starknetSelector(from: "increase_balance"), calldata: [100_000_000_000])
 
         let params1 = StarknetInvokeParamsV1(nonce: nonce, maxFee: 0)
-        let tx1 = try await account.signV1(calls: [call], params: params1, forFeeEstimation: true)
+        let tx1 = try account.signV1(calls: [call], params: params1, forFeeEstimation: true)
 
         let params2 = StarknetInvokeParamsV1(nonce: Felt(nonce.value + 1)!, maxFee: 0)
-        let tx2 = try await account.signV1(calls: [call, call2], params: params2, forFeeEstimation: true)
+        let tx2 = try account.signV1(calls: [call, call2], params: params2, forFeeEstimation: true)
 
         let _ = try await provider.estimateFee(for: [tx1, tx2], simulationFlags: [])
 
@@ -232,10 +232,10 @@ final class ProviderTests: XCTestCase {
         let call2 = StarknetCall(contractAddress: contractAddress, entrypoint: starknetSelector(from: "increase_balance"), calldata: [100_000_000_000])
 
         let params1 = StarknetInvokeParamsV3(nonce: nonce, l1ResourceBounds: .zero)
-        let tx1 = try await account.signV3(calls: [call], params: params1, forFeeEstimation: true)
+        let tx1 = try account.signV3(calls: [call], params: params1, forFeeEstimation: true)
 
         let params2 = StarknetInvokeParamsV3(nonce: Felt(nonce.value + 1)!, l1ResourceBounds: .zero)
-        let tx2 = try await account.signV3(calls: [call, call2], params: params2, forFeeEstimation: true)
+        let tx2 = try account.signV3(calls: [call, call2], params: params2, forFeeEstimation: true)
 
         let _ = try await provider.estimateFee(for: [tx1, tx2], simulationFlags: [])
 
@@ -257,7 +257,7 @@ final class ProviderTests: XCTestCase {
 
         let params = StarknetDeployAccountParamsV1(nonce: nonce, maxFee: .zero)
 
-        let tx = try await newAccount.signDeployAccountV1(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero, params: params, forFeeEstimation: true)
+        let tx = try newAccount.signDeployAccountV1(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero, params: params, forFeeEstimation: true)
 
         let _ = try await provider.estimateFee(for: tx, simulationFlags: [])
 
@@ -278,7 +278,7 @@ final class ProviderTests: XCTestCase {
 
         let params = StarknetDeployAccountParamsV3(nonce: nonce, l1ResourceBounds: .zero)
 
-        let tx = try await newAccount.signDeployAccountV3(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero, params: params, forFeeEstimation: true)
+        let tx = try newAccount.signDeployAccountV3(classHash: accountContractClassHash, calldata: [newPublicKey], salt: .zero, params: params, forFeeEstimation: true)
 
         let _ = try await provider.estimateFee(for: tx)
 
@@ -319,7 +319,7 @@ final class ProviderTests: XCTestCase {
         let call = StarknetCall(contractAddress: contract.deploy.contractAddress, entrypoint: starknetSelector(from: "increase_balance"), calldata: [1000])
         let params = StarknetInvokeParamsV1(nonce: nonce, maxFee: 500_000_000_000_000)
 
-        let invokeTx = try await account.signV1(calls: [call], params: params, forFeeEstimation: false)
+        let invokeTx = try account.signV1(calls: [call], params: params, forFeeEstimation: false)
 
         let accountClassHash = try await provider.getClassHashAt(account.address)
         let newSigner = StarkCurveSigner(privateKey: 1001)!
@@ -330,7 +330,7 @@ final class ProviderTests: XCTestCase {
         try await Self.devnetClient.prefundAccount(address: newAccountAddress)
 
         let newAccountParams = StarknetDeployAccountParamsV1(nonce: .zero, maxFee: 500_000_000_000_000)
-        let deployAccountTx = try await newAccount.signDeployAccountV1(classHash: accountClassHash, calldata: [newPublicKey], salt: .zero, params: newAccountParams, forFeeEstimation: false)
+        let deployAccountTx = try newAccount.signDeployAccountV1(classHash: accountClassHash, calldata: [newPublicKey], salt: .zero, params: newAccountParams, forFeeEstimation: false)
 
         let simulations = try await provider.simulateTransactions([invokeTx, deployAccountTx], at: .tag(.pending), simulationFlags: [])
 
@@ -360,7 +360,7 @@ final class ProviderTests: XCTestCase {
         let invokeL1Gas = StarknetResourceBounds(maxAmount: 500_000, maxPricePerUnit: 100_000_000_000)
         let params = StarknetInvokeParamsV3(nonce: nonce, l1ResourceBounds: invokeL1Gas)
 
-        let invokeTx = try await account.signV3(calls: [call], params: params, forFeeEstimation: false)
+        let invokeTx = try account.signV3(calls: [call], params: params, forFeeEstimation: false)
 
         let accountClassHash = try await provider.getClassHashAt(account.address)
         let newSigner = StarkCurveSigner(privateKey: 3003)!
@@ -372,7 +372,7 @@ final class ProviderTests: XCTestCase {
 
         let deployAccountL1Gas = StarknetResourceBounds(maxAmount: 500_000, maxPricePerUnit: 100_000_000_000)
         let newAccountParams = StarknetDeployAccountParamsV3(nonce: 0, l1ResourceBounds: deployAccountL1Gas)
-        let deployAccountTx = try await newAccount.signDeployAccountV3(classHash: accountClassHash, calldata: [newPublicKey], salt: .zero, params: newAccountParams, forFeeEstimation: false)
+        let deployAccountTx = try newAccount.signDeployAccountV3(classHash: accountClassHash, calldata: [newPublicKey], salt: .zero, params: newAccountParams, forFeeEstimation: false)
 
         let simulations = try await provider.simulateTransactions([invokeTx, deployAccountTx], at: .tag(.pending), simulationFlags: [])
 


### PR DESCRIPTION
## Describe your changes

As part of https://github.com/software-mansion/starknet.swift/pull/151, https://github.com/software-mansion/starknet.swift/pull/154, https://github.com/software-mansion/starknet.swift/pull/155, which have restored the ability to set a specific chain ID during initialization and eliminated the need to fetch it at runtime, it is no longer necessary to define all signing methods as asynchronous.

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
