### PR TITLE
Add `execute` methods with custom fee multipliers

### DIFF
--- a/Sources/Starknet/Accounts/StarknetAccountProtocol.swift
+++ b/Sources/Starknet/Accounts/StarknetAccountProtocol.swift
@@ -85,6 +85,8 @@ public protocol StarknetAccountProtocol {
     /// - Returns: InvokeTransactionResponse, containing transaction hash of submitted transaction.
     func executeV3(calls: [StarknetCall], params: StarknetOptionalInvokeParamsV3) async throws -> StarknetInvokeTransactionResponse
 
+    func executeV1(calls: [StarknetCall], estimateFeeMultiplier: Double) async throws -> StarknetInvokeTransactionResponse
+    func executeV3(calls: [StarknetCall], estimateAmountMultiplier: Double, estimateUnitPriceMultiplier: Double) async throws -> StarknetInvokeTransactionResponse
     /// Execute list of calls as invoke transaction v1
     ///
     /// - Parameters:
@@ -268,6 +270,33 @@ public extension StarknetAccountProtocol {
     func executeV3(call: StarknetCall, params: StarknetOptionalInvokeParamsV3) async throws -> StarknetInvokeTransactionResponse {
         try await executeV3(calls: [call], params: params)
     }
+
+    /// Execute a call as invoke transaction v1
+        ///
+        /// Execute a call as invoke transaction v1 with automatically estimated fee that will be multiplied by the specified multiplier when max fee is calculated.
+        ///
+        /// - Parameters:
+        ///  - call: a call to be executed.
+        ///  - estimateFeeMultiplier: multiplier for the estimated fee.
+        ///
+        /// - Returns: InvokeTransactionResponse, containing transaction hash of submitted transaction.
+        func executeV1(call: StarknetCall, estimateFeeMultiplier: Double) async throws -> StarknetInvokeTransactionResponse {
+            try await executeV1(calls: [call], estimateFeeMultiplier: estimateFeeMultiplier)
+        }
+
+        /// Execute a call as invoke transaction v3
+        ///
+        /// Execute a call as invoke transaction v3 with automatically estimated fee that will be multiplied by the specified multipliers when resource bounds are calculated.
+        ///
+        /// - Parameters:
+        ///  - call: a call to be executed.
+        ///  - estimateAmountMultiplier: multiplier for the estimated amount.
+        ///  - estimateUnitPriceMultiplier: multiplier for the estimated unit price.
+        ///
+        ///  - Returns: InvokeTransactionResponse, containing transaction hash of submitted transaction.
+        func executeV3(call: StarknetCall, estimateAmountMultiplier: Double, estimateUnitPriceMultiplier: Double) async throws -> StarknetInvokeTransactionResponse {
+            try await executeV3(calls: [call], estimateAmountMultiplier: estimateAmountMultiplier, estimateUnitPriceMultiplier: estimateUnitPriceMultiplier)
+        }
 
     /// Execute a call as invoke transaction v1
     ///

--- a/Sources/Starknet/Accounts/StarknetAccountProtocol.swift
+++ b/Sources/Starknet/Accounts/StarknetAccountProtocol.swift
@@ -85,8 +85,6 @@ public protocol StarknetAccountProtocol {
     /// - Returns: InvokeTransactionResponse, containing transaction hash of submitted transaction.
     func executeV3(calls: [StarknetCall], params: StarknetOptionalInvokeParamsV3) async throws -> StarknetInvokeTransactionResponse
 
-    /// Execute list of calls as invoke transaction v1
-    ///
     /// Execute list of calls as invoke transaction v1 with automatically estimated fee that will be multiplied by the specified multiplier when max fee is calculated.
     ///
     /// - Parameters:
@@ -96,8 +94,6 @@ public protocol StarknetAccountProtocol {
     /// - Returns: InvokeTransactionResponse, containing transaction hash of submitted transaction.
     func executeV1(calls: [StarknetCall], estimateFeeMultiplier: Double) async throws -> StarknetInvokeTransactionResponse
 
-    /// Execute list of calls as invoke transaction v3
-    ///
     /// Execute list of calls as invoke transaction v3 with automatically estimated fee that will be multiplied by the specified multipliers when resource bounds are calculated.
     ///
     /// - Parameters:
@@ -108,8 +104,6 @@ public protocol StarknetAccountProtocol {
     ///  - Returns: InvokeTransactionResponse, containing transaction hash of submitted transaction.
     func executeV3(calls: [StarknetCall], estimateAmountMultiplier: Double, estimateUnitPriceMultiplier: Double) async throws -> StarknetInvokeTransactionResponse
 
-    /// Execute list of calls as invoke transaction v1
-    ///
     /// Execute list of calls as invoke transaction v1 with automatically estimated fee
     ///
     /// - Parameters:
@@ -118,8 +112,6 @@ public protocol StarknetAccountProtocol {
     /// - Returns: InvokeTransactionResponse, containing transaction hash of submitted transaction.
     func executeV1(calls: [StarknetCall]) async throws -> StarknetInvokeTransactionResponse
 
-    /// Execute list of calls as invoke transaction v3
-    ///
     /// Execute list of calls as invoke transaction v3 with automatically estimated fee
     ///
     /// - Parameters:

--- a/Sources/Starknet/Accounts/StarknetAccountProtocol.swift
+++ b/Sources/Starknet/Accounts/StarknetAccountProtocol.swift
@@ -288,8 +288,6 @@ public extension StarknetAccountProtocol {
         try await executeV3(calls: [call], params: params)
     }
 
-    /// Execute a call as invoke transaction v1
-    ///
     /// Execute a call as invoke transaction v1 with automatically estimated fee that will be multiplied by the specified multiplier when max fee is calculated.
     ///
     /// - Parameters:
@@ -301,8 +299,6 @@ public extension StarknetAccountProtocol {
         try await executeV1(calls: [call], estimateFeeMultiplier: estimateFeeMultiplier)
     }
 
-    /// Execute a call as invoke transaction v3
-    ///
     /// Execute a call as invoke transaction v3 with automatically estimated fee that will be multiplied by the specified multipliers when resource bounds are calculated.
     ///
     /// - Parameters:
@@ -315,8 +311,6 @@ public extension StarknetAccountProtocol {
         try await executeV3(calls: [call], estimateAmountMultiplier: estimateAmountMultiplier, estimateUnitPriceMultiplier: estimateUnitPriceMultiplier)
     }
 
-    /// Execute a call as invoke transaction v1
-    ///
     /// Execute a call as invoke transaction v1 with automatically estimated fee
     ///
     /// - Parameters:
@@ -327,8 +321,6 @@ public extension StarknetAccountProtocol {
         try await executeV1(calls: [call])
     }
 
-    /// Execute a call as invoke transaction v3
-    ///
     /// Execute a call as invoke transaction v3 with automatically estimated fee
     ///
     /// - Parameters:

--- a/Sources/Starknet/Accounts/StarknetAccountProtocol.swift
+++ b/Sources/Starknet/Accounts/StarknetAccountProtocol.swift
@@ -85,8 +85,29 @@ public protocol StarknetAccountProtocol {
     /// - Returns: InvokeTransactionResponse, containing transaction hash of submitted transaction.
     func executeV3(calls: [StarknetCall], params: StarknetOptionalInvokeParamsV3) async throws -> StarknetInvokeTransactionResponse
 
+    /// Execute list of calls as invoke transaction v1
+    ///
+    /// Execute list of calls as invoke transaction v1 with automatically estimated fee that will be multiplied by the specified multiplier when max fee is calculated.
+    ///
+    /// - Parameters:
+    ///  - calls: list of calls to be executed.
+    ///  - estimateFeeMultiplier: multiplier for the estimated fee.
+    ///
+    /// - Returns: InvokeTransactionResponse, containing transaction hash of submitted transaction.
     func executeV1(calls: [StarknetCall], estimateFeeMultiplier: Double) async throws -> StarknetInvokeTransactionResponse
+
+    /// Execute list of calls as invoke transaction v3
+    ///
+    /// Execute list of calls as invoke transaction v3 with automatically estimated fee that will be multiplied by the specified multipliers when resource bounds are calculated.
+    ///
+    /// - Parameters:
+    ///  - calls: list of calls to be executed.
+    ///  - estimateAmountMultiplier: multiplier for the estimated amount.
+    ///  - estimateUnitPriceMultiplier: multiplier for the estimated unit price.
+    ///
+    ///  - Returns: InvokeTransactionResponse, containing transaction hash of submitted transaction.
     func executeV3(calls: [StarknetCall], estimateAmountMultiplier: Double, estimateUnitPriceMultiplier: Double) async throws -> StarknetInvokeTransactionResponse
+
     /// Execute list of calls as invoke transaction v1
     ///
     /// - Parameters:
@@ -272,31 +293,31 @@ public extension StarknetAccountProtocol {
     }
 
     /// Execute a call as invoke transaction v1
-        ///
-        /// Execute a call as invoke transaction v1 with automatically estimated fee that will be multiplied by the specified multiplier when max fee is calculated.
-        ///
-        /// - Parameters:
-        ///  - call: a call to be executed.
-        ///  - estimateFeeMultiplier: multiplier for the estimated fee.
-        ///
-        /// - Returns: InvokeTransactionResponse, containing transaction hash of submitted transaction.
-        func executeV1(call: StarknetCall, estimateFeeMultiplier: Double) async throws -> StarknetInvokeTransactionResponse {
-            try await executeV1(calls: [call], estimateFeeMultiplier: estimateFeeMultiplier)
-        }
+    ///
+    /// Execute a call as invoke transaction v1 with automatically estimated fee that will be multiplied by the specified multiplier when max fee is calculated.
+    ///
+    /// - Parameters:
+    ///  - call: a call to be executed.
+    ///  - estimateFeeMultiplier: multiplier for the estimated fee.
+    ///
+    /// - Returns: InvokeTransactionResponse, containing transaction hash of submitted transaction.
+    func executeV1(call: StarknetCall, estimateFeeMultiplier: Double) async throws -> StarknetInvokeTransactionResponse {
+        try await executeV1(calls: [call], estimateFeeMultiplier: estimateFeeMultiplier)
+    }
 
-        /// Execute a call as invoke transaction v3
-        ///
-        /// Execute a call as invoke transaction v3 with automatically estimated fee that will be multiplied by the specified multipliers when resource bounds are calculated.
-        ///
-        /// - Parameters:
-        ///  - call: a call to be executed.
-        ///  - estimateAmountMultiplier: multiplier for the estimated amount.
-        ///  - estimateUnitPriceMultiplier: multiplier for the estimated unit price.
-        ///
-        ///  - Returns: InvokeTransactionResponse, containing transaction hash of submitted transaction.
-        func executeV3(call: StarknetCall, estimateAmountMultiplier: Double, estimateUnitPriceMultiplier: Double) async throws -> StarknetInvokeTransactionResponse {
-            try await executeV3(calls: [call], estimateAmountMultiplier: estimateAmountMultiplier, estimateUnitPriceMultiplier: estimateUnitPriceMultiplier)
-        }
+    /// Execute a call as invoke transaction v3
+    ///
+    /// Execute a call as invoke transaction v3 with automatically estimated fee that will be multiplied by the specified multipliers when resource bounds are calculated.
+    ///
+    /// - Parameters:
+    ///  - call: a call to be executed.
+    ///  - estimateAmountMultiplier: multiplier for the estimated amount.
+    ///  - estimateUnitPriceMultiplier: multiplier for the estimated unit price.
+    ///
+    ///  - Returns: InvokeTransactionResponse, containing transaction hash of submitted transaction.
+    func executeV3(call: StarknetCall, estimateAmountMultiplier: Double, estimateUnitPriceMultiplier: Double) async throws -> StarknetInvokeTransactionResponse {
+        try await executeV3(calls: [call], estimateAmountMultiplier: estimateAmountMultiplier, estimateUnitPriceMultiplier: estimateUnitPriceMultiplier)
+    }
 
     /// Execute a call as invoke transaction v1
     ///

--- a/Sources/Starknet/Accounts/StarknetAccountProtocol.swift
+++ b/Sources/Starknet/Accounts/StarknetAccountProtocol.swift
@@ -110,6 +110,8 @@ public protocol StarknetAccountProtocol {
 
     /// Execute list of calls as invoke transaction v1
     ///
+    /// Execute list of calls as invoke transaction v1 with automatically estimated fee
+    ///
     /// - Parameters:
     ///  - calls: list of calls to be executed.
     ///
@@ -117,6 +119,8 @@ public protocol StarknetAccountProtocol {
     func executeV1(calls: [StarknetCall]) async throws -> StarknetInvokeTransactionResponse
 
     /// Execute list of calls as invoke transaction v3
+    ///
+    /// Execute list of calls as invoke transaction v1 with automatically estimated fee
     ///
     /// - Parameters:
     ///  - calls: list of calls to be executed.
@@ -321,6 +325,8 @@ public extension StarknetAccountProtocol {
 
     /// Execute a call as invoke transaction v1
     ///
+    /// Execute a call as invoke transaction v1 with automatically estimated fee
+    ///
     /// - Parameters:
     ///  - call: a call to be executed.
     ///
@@ -330,6 +336,8 @@ public extension StarknetAccountProtocol {
     }
 
     /// Execute a call as invoke transaction v3
+    ///
+    /// Execute a call as invoke transaction v1 with automatically estimated fee
     ///
     /// - Parameters:
     ///  - call: a call to be executed.

--- a/Sources/Starknet/Accounts/StarknetAccountProtocol.swift
+++ b/Sources/Starknet/Accounts/StarknetAccountProtocol.swift
@@ -120,7 +120,7 @@ public protocol StarknetAccountProtocol {
 
     /// Execute list of calls as invoke transaction v3
     ///
-    /// Execute list of calls as invoke transaction v1 with automatically estimated fee
+    /// Execute list of calls as invoke transaction v3 with automatically estimated fee
     ///
     /// - Parameters:
     ///  - calls: list of calls to be executed.
@@ -337,7 +337,7 @@ public extension StarknetAccountProtocol {
 
     /// Execute a call as invoke transaction v3
     ///
-    /// Execute a call as invoke transaction v1 with automatically estimated fee
+    /// Execute a call as invoke transaction v3 with automatically estimated fee
     ///
     /// - Parameters:
     ///  - call: a call to be executed.

--- a/Sources/Starknet/Crypto/FeeCalculation.swift
+++ b/Sources/Starknet/Crypto/FeeCalculation.swift
@@ -9,10 +9,10 @@ public extension StarknetFeeEstimate {
     /// Then multiplies `maxAmount` by **round((amountMultiplier) \* 100%)** and `maxPricePerUnit` by **round((unitPriceMultiplier) \* 100%)** and performs integer division by 100 on both.
     ///
     /// - Parameters:
-    ///  - amountMultiplier: Multiplier for max amount, defaults to 1.5.
-    ///  - unitPriceMultiplier: Multiplier for max price per unit, defaults to 1.5.
+    ///  - amountMultiplier: multiplier for max amount, defaults to 1.5.
+    ///  - unitPriceMultiplier: multiplier for max price per unit, defaults to 1.5.
     ///
-    /// - Returns: Resource bounds with applied multipliers
+    /// - Returns: resource bounds with applied multipliers
     func toResourceBounds(amountMultiplier: Double = 1.5, unitPriceMultiplier: Double = 1.5) -> StarknetResourceBoundsMapping {
         let maxAmount = self.gasPrice == .zero ? UInt64AsHex.zero : (self.overallFee.value / self.gasPrice.value).applyMultiplier(amountMultiplier).toUInt64AsHexClamped()
 
@@ -27,9 +27,9 @@ public extension StarknetFeeEstimate {
     /// Multiplies `overallFee` by **round(multiplier] \* 100%)** and performs integer division by 100.
     ///
     /// - Parameters:
-    ///  - multiplier: Multiplier for max fee, defaults to 1.5.
+    ///  - multiplier: multiplier for max fee, defaults to 1.5.
     ///
-    /// - Returns: Fee with applied multiplier
+    /// - Returns: fee with applied multiplier
     func toMaxFee(multiplier: Double = 1.5) -> Felt {
         self.overallFee.value.applyMultiplier(multiplier).toFeltClamped()
     }

--- a/Sources/Starknet/Crypto/FeeCalculation.swift
+++ b/Sources/Starknet/Crypto/FeeCalculation.swift
@@ -29,7 +29,7 @@ public extension StarknetFeeEstimate {
     /// - Parameters:
     ///  - multiplier: Multiplier for max fee, defaults to 1.5.
     ///
-    /// - Returns: Fee with added overhead
+    /// - Returns: Fee with applied multiplier
     func toMaxFee(multiplier: Double = 1.5) -> Felt {
         self.overallFee.value.applyMultiplier(multiplier).toFeltClamped()
     }

--- a/Sources/Starknet/Crypto/FeeCalculation.swift
+++ b/Sources/Starknet/Crypto/FeeCalculation.swift
@@ -6,7 +6,7 @@ public extension StarknetFeeEstimate {
     ///
     /// Calculates `maxAmount = overallFee / gasPrice`, unless `gasPrice` is 0, then `maxAmount` is 0.
     /// Calculates `maxPricePerUnit = gasPrice`.
-    /// Then multiplies `maxAmount` by **round((amountMultiplier) \* 100%)** and `maxPricePerUnit` by **round((unitPriceMultiplier) \* 100%)** and performs integer division by 100 on both.
+    /// Then multiplies `maxAmount` by **round((amountMultiplier) \* 100)** and `maxPricePerUnit` by **round((unitPriceMultiplier) \* 100)** and performs integer division by 100 on both.
     ///
     /// - Parameters:
     ///  - amountMultiplier: multiplier for max amount, defaults to 1.5.
@@ -24,7 +24,7 @@ public extension StarknetFeeEstimate {
 
     /// Convert estimated fee to max fee with applied multiplier.
     ///
-    /// Multiplies `overallFee` by **round(multiplier] \* 100%)** and performs integer division by 100.
+    /// Multiplies `overallFee` by **round(multiplier \* 100)** and performs integer division by 100.
     ///
     /// - Parameters:
     ///  - multiplier: multiplier for estimated fee, defaults to 1.5.

--- a/Sources/Starknet/Crypto/FeeCalculation.swift
+++ b/Sources/Starknet/Crypto/FeeCalculation.swift
@@ -27,7 +27,7 @@ public extension StarknetFeeEstimate {
     /// Multiplies `overallFee` by **round(multiplier] \* 100%)** and performs integer division by 100.
     ///
     /// - Parameters:
-    ///  - multiplier: multiplier for max fee, defaults to 1.5.
+    ///  - multiplier: multiplier for estimated fee, defaults to 1.5.
     ///
     /// - Returns: fee with applied multiplier
     func toMaxFee(multiplier: Double = 1.5) -> Felt {

--- a/Tests/StarknetTests/Accounts/AccountTest.swift
+++ b/Tests/StarknetTests/Accounts/AccountTest.swift
@@ -77,6 +77,32 @@ final class AccountTests: XCTestCase {
         try await Self.devnetClient.assertTransactionSucceeded(transactionHash: result.transactionHash)
     }
 
+    func testExecuteV1FeeMultiplier() async throws {
+        let recipientAddress = AccountTests.devnetClient.constants.predeployedAccount2.address
+
+        let calldata: [Felt] = [recipientAddress, 1000, 0]
+        let call = StarknetCall(contractAddress: ethContractAddress, entrypoint: starknetSelector(from: "transfer"), calldata: calldata)
+
+        let result = try await account.executeV1(call: call, estimateFeeMultiplier: 1.8)
+        try await Self.devnetClient.assertTransactionSucceeded(transactionHash: result.transactionHash)
+
+        let result2 = try await account.executeV1(call: call, estimateFeeMultiplier: 0.9)
+        try await Self.devnetClient.assertTransactionFailed(transactionHash: result2.transactionHash)
+    }
+
+    func testExecuteV3FeeMultiplier() async throws {
+        let recipientAddress = AccountTests.devnetClient.constants.predeployedAccount2.address
+
+        let calldata: [Felt] = [recipientAddress, 1000, 0]
+        let call = StarknetCall(contractAddress: ethContractAddress, entrypoint: starknetSelector(from: "transfer"), calldata: calldata)
+
+        let result = try await account.executeV3(call: call, estimateAmountMultiplier: 1.8, estimateUnitPriceMultiplier: 1.8)
+        try await Self.devnetClient.assertTransactionSucceeded(transactionHash: result.transactionHash)
+
+        let result2 = try await account.executeV3(call: call, estimateAmountMultiplier: 0.9, estimateUnitPriceMultiplier: 1.0)
+        try await Self.devnetClient.assertTransactionFailed(transactionHash: result2.transactionHash)
+    }
+
     func testExecuteCustomParams() async throws {
         let recipientAddress = AccountTests.devnetClient.constants.predeployedAccount2.address
 

--- a/Tests/StarknetTests/Accounts/AccountTest.swift
+++ b/Tests/StarknetTests/Accounts/AccountTest.swift
@@ -90,7 +90,7 @@ final class AccountTests: XCTestCase {
         try await Self.devnetClient.assertTransactionFailed(transactionHash: result2.transactionHash)
     }
 
-    func testExecuteV3FeeMultiplier() async throws {
+    func testExecuteV3FeeMultipliers() async throws {
         let recipientAddress = AccountTests.devnetClient.constants.predeployedAccount2.address
 
         let calldata: [Felt] = [recipientAddress, 1000, 0]

--- a/Tests/StarknetTests/Crypto/FeeEstimateTests.swift
+++ b/Tests/StarknetTests/Crypto/FeeEstimateTests.swift
@@ -6,15 +6,15 @@ final class FeeEstimateTests: XCTestCase {
     func testEstimateFeeToResourceBounds() {
         let cases: [(StarknetFeeEstimate, Double, Double, StarknetResourceBounds)] =
             [
-                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 2138, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 21380, feeUnit: .wei), 0.1, 0.5, StarknetResourceBounds(maxAmount: 11, maxPricePerUnit: 3207)),
-                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 1000, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 10000, feeUnit: .wei), 0, 0, StarknetResourceBounds(maxAmount: 10, maxPricePerUnit: 1000)),
-                (StarknetFeeEstimate(gasConsumed: Felt(UInt64AsHex.max.value - 100)!, gasPrice: Felt(UInt128AsHex.max.value - 100)!, dataGasConsumed: Felt.max, dataGasPrice: 10, overallFee: Felt.max, feeUnit: .wei), 0.1, 0.5, StarknetResourceBounds(maxAmount: UInt64AsHex.max, maxPricePerUnit: UInt128AsHex.max)),
-                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 0, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 10, feeUnit: .wei), 0.5, 0.5, StarknetResourceBounds(maxAmount: 0, maxPricePerUnit: 0)),
-                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 2000, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 20000, feeUnit: .wei), 1, 1, StarknetResourceBounds(maxAmount: 20, maxPricePerUnit: 4000)),
+                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 2138, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 21380, feeUnit: .wei), 1.1, 1.5, StarknetResourceBounds(maxAmount: 11, maxPricePerUnit: 3207)),
+                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 1000, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 10000, feeUnit: .wei), 1.0, 1.0, StarknetResourceBounds(maxAmount: 10, maxPricePerUnit: 1000)),
+                (StarknetFeeEstimate(gasConsumed: Felt(UInt64AsHex.max.value - 100)!, gasPrice: Felt(UInt128AsHex.max.value - 100)!, dataGasConsumed: Felt.max, dataGasPrice: 10, overallFee: Felt.max, feeUnit: .wei), 1.1, 1.5, StarknetResourceBounds(maxAmount: UInt64AsHex.max, maxPricePerUnit: UInt128AsHex.max)),
+                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 0, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 10, feeUnit: .wei), 1.5, 1.5, StarknetResourceBounds(maxAmount: 0, maxPricePerUnit: 0)),
+                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 2000, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 20000, feeUnit: .wei), 2, 2, StarknetResourceBounds(maxAmount: 20, maxPricePerUnit: 4000)),
             ]
 
         cases.forEach {
-            let resourceBounds = $0.toResourceBounds(amountOverhead: $1, unitPriceOverhead: $2)
+            let resourceBounds = $0.toResourceBounds(amountMultiplier: $1, unitPriceMultiplier: $2)
             let expected = StarknetResourceBoundsMapping(l1Gas: $3)
 
             XCTAssertEqual(resourceBounds.l1Gas.maxAmount, expected.l1Gas.maxAmount)
@@ -28,15 +28,15 @@ final class FeeEstimateTests: XCTestCase {
     func testEstimateFeeToMaxFee() {
         let cases: [(StarknetFeeEstimate, Double, Felt)] =
             [
-                (StarknetFeeEstimate(gasConsumed: 1, gasPrice: 2138, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 2138, feeUnit: .wei), 0.1, 2351),
-                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 1000, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 10000, feeUnit: .wei), 0, 10000),
-                (StarknetFeeEstimate(gasConsumed: Felt(UInt64AsHex.max.value - 100)!, gasPrice: Felt(UInt128AsHex.max.value - 100)!, dataGasConsumed: 10, dataGasPrice: 1, overallFee: Felt.max, feeUnit: .wei), 0.1, Felt.max),
-                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 0, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 0, feeUnit: .wei), 0.5, 0),
-                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 2000, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 20000, feeUnit: .wei), 1, 40000),
+                (StarknetFeeEstimate(gasConsumed: 1, gasPrice: 2138, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 2138, feeUnit: .wei), 1.1, 2351),
+                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 1000, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 10000, feeUnit: .wei), 1.0, 10000),
+                (StarknetFeeEstimate(gasConsumed: Felt(UInt64AsHex.max.value - 100)!, gasPrice: Felt(UInt128AsHex.max.value - 100)!, dataGasConsumed: 10, dataGasPrice: 1, overallFee: Felt.max, feeUnit: .wei), 1.1, Felt.max),
+                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 0, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 0, feeUnit: .wei), 1.5, 0),
+                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 2000, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 20000, feeUnit: .wei), 2, 40000),
             ]
 
         cases.forEach {
-            let estimated = $0.toMaxFee(overhead: $1)
+            let estimated = $0.toMaxFee(multiplier: $1)
             XCTAssertEqual(estimated, $2)
         }
     }


### PR DESCRIPTION
## Stack

-- Support RPC 0.7.0 (#162)
-- Add `execute` methods with custom fee multipliers (#163) 
-- Add transaction version enum (#164)
-- Refactor receipts (#165)

## Describe your changes

<!-- A brief description of the changes introduced in this PR -->
- Use multipliers instead of overheads in fee calculation utils
- Add `executeV1`, `executeV3` methods in `StarknetAccount` with estimate fee multipliers
  - Update docstrings for `executeVX` with `call(s)` as only argument to be in line with the new methods

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [x] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->

- `StarknetFeeEstimate` extension fee calculation utils
  - `toResourceBounds()` now takes `amountMultiplier`, `unitPriceMultiplier` instead of `amountOverhead`, `unitPriceOverhead`
  - `toMaxFee()` now takes `multiplier` instead of `overhead`
