### PR TITLE
Add transaction version enum

### DIFF
--- a/Sources/Starknet/Data/Transaction/Data/StarknetTransactionVersion.swift
+++ b/Sources/Starknet/Data/Transaction/Data/StarknetTransactionVersion.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public enum StarknetTransactionVersion: String, Codable {
+    case v0 = "0x0"
+    case v1 = "0x1"
+    case v1Query = "0x100000000000000000000000000000001"
+    case v2 = "0x2"
+    case v2Query = "0x100000000000000000000000000000002"
+    case v3 = "0x3"
+    case v3Query = "0x100000000000000000000000000000003"
+
+    public var value: Felt {
+        Felt(fromHex: self.rawValue)!
+    }
+}

--- a/Sources/Starknet/Data/Transaction/Transaction.swift
+++ b/Sources/Starknet/Data/Transaction/Transaction.swift
@@ -4,7 +4,7 @@ import Foundation
 public struct StarknetInvokeTransactionV3: StarknetInvokeTransaction, StarknetTransactionV3, StarknetExecutableTransaction {
     public let type: StarknetTransactionType = .invoke
 
-    public let version: Felt
+    public let version: StarknetTransactionVersion
 
     public let senderAddress: Felt
 
@@ -33,7 +33,7 @@ public struct StarknetInvokeTransactionV3: StarknetInvokeTransaction, StarknetTr
         self.calldata = calldata
         self.signature = signature
         self.nonce = nonce
-        self.version = StarknetInvokeTransactionV3.computeVersion(3, forFeeEstimation: forFeeEstimation)
+        self.version = forFeeEstimation ? .v3Query : .v3
         self.hash = hash
         // As of Starknet 0.13, most of v3 fields have hardcoded values.
         self.resourceBounds = StarknetResourceBoundsMapping(l1Gas: l1ResourceBounds)
@@ -66,7 +66,7 @@ public struct StarknetInvokeTransactionV3: StarknetInvokeTransaction, StarknetTr
         self.calldata = try container.decode(StarknetCalldata.self, forKey: .calldata)
         self.signature = try container.decode(StarknetSignature.self, forKey: .signature)
         self.nonce = try container.decode(Felt.self, forKey: .nonce)
-        self.version = try container.decode(Felt.self, forKey: .version)
+        self.version = try container.decode(StarknetTransactionVersion.self, forKey: .version)
         self.resourceBounds = try container.decode(StarknetResourceBoundsMapping.self, forKey: .resourceBounds)
         self.tip = try container.decode(UInt64AsHex.self, forKey: .tip)
         self.paymasterData = try container.decode(StarknetPaymasterData.self, forKey: .paymasterData)
@@ -82,7 +82,7 @@ public struct StarknetInvokeTransactionV3: StarknetInvokeTransaction, StarknetTr
 public struct StarknetInvokeTransactionV1: StarknetInvokeTransaction, StarknetDeprecatedTransaction, StarknetExecutableTransaction {
     public let type: StarknetTransactionType = .invoke
 
-    public let version: Felt
+    public let version: StarknetTransactionVersion
 
     public let senderAddress: Felt
 
@@ -102,7 +102,7 @@ public struct StarknetInvokeTransactionV1: StarknetInvokeTransaction, StarknetDe
         self.signature = signature
         self.maxFee = maxFee
         self.nonce = nonce
-        self.version = StarknetInvokeTransactionV1.computeVersion(1, forFeeEstimation: forFeeEstimation)
+        self.version = forFeeEstimation ? .v1Query : .v1
         self.hash = hash
     }
 
@@ -124,7 +124,7 @@ public struct StarknetInvokeTransactionV1: StarknetInvokeTransaction, StarknetDe
         self.signature = try container.decode(StarknetSignature.self, forKey: .signature)
         self.maxFee = try container.decode(Felt.self, forKey: .maxFee)
         self.nonce = try container.decode(Felt.self, forKey: .nonce)
-        self.version = try container.decode(Felt.self, forKey: .version)
+        self.version = try container.decode(StarknetTransactionVersion.self, forKey: .version)
         self.hash = try container.decodeIfPresent(Felt.self, forKey: .hash)
 
         try verifyTransactionType(container: container, codingKeysType: CodingKeys.self)
@@ -134,7 +134,7 @@ public struct StarknetInvokeTransactionV1: StarknetInvokeTransaction, StarknetDe
 public struct StarknetInvokeTransactionV0: StarknetInvokeTransaction, StarknetDeprecatedTransaction {
     public let type: StarknetTransactionType = .invoke
 
-    public let version: Felt = .zero
+    public let version: StarknetTransactionVersion = .v0
 
     public let contractAddress: Felt
 
@@ -185,7 +185,7 @@ public struct StarknetInvokeTransactionV0: StarknetInvokeTransaction, StarknetDe
 public struct StarknetDeployAccountTransactionV3: StarknetDeployAccountTransaction, StarknetTransactionV3, StarknetExecutableTransaction {
     public let type: StarknetTransactionType = .deployAccount
 
-    public let version: Felt
+    public let version: StarknetTransactionVersion
 
     public let signature: StarknetSignature
 
@@ -215,7 +215,7 @@ public struct StarknetDeployAccountTransactionV3: StarknetDeployAccountTransacti
         self.contractAddressSalt = contractAddressSalt
         self.constructorCalldata = constructorCalldata
         self.classHash = classHash
-        self.version = StarknetDeployAccountTransactionV3.computeVersion(3, forFeeEstimation: forFeeEstimation)
+        self.version = forFeeEstimation ? .v3Query : .v3
         self.hash = hash
         // As of Starknet 0.13, most of v3 fields have hardcoded values.
         self.resourceBounds = StarknetResourceBoundsMapping(l1Gas: l1ResourceBounds)
@@ -237,7 +237,7 @@ public struct StarknetDeployAccountTransactionV3: StarknetDeployAccountTransacti
         self.paymasterData = try container.decode([Felt].self, forKey: .paymasterData)
         self.nonceDataAvailabilityMode = try container.decode(StarknetDAMode.self, forKey: .nonceDataAvailabilityMode)
         self.feeDataAvailabilityMode = try container.decode(StarknetDAMode.self, forKey: .feeDataAvailabilityMode)
-        self.version = try container.decode(Felt.self, forKey: .version)
+        self.version = try container.decode(StarknetTransactionVersion.self, forKey: .version)
         self.hash = try container.decodeIfPresent(Felt.self, forKey: .hash)
 
         try verifyTransactionVersion(container: container, codingKeysType: CodingKeys.self)
@@ -263,7 +263,7 @@ public struct StarknetDeployAccountTransactionV3: StarknetDeployAccountTransacti
 public struct StarknetDeployAccountTransactionV1: StarknetDeployAccountTransaction, StarknetDeprecatedTransaction, StarknetExecutableTransaction {
     public let type: StarknetTransactionType = .deployAccount
 
-    public let version: Felt
+    public let version: StarknetTransactionVersion
 
     public let signature: StarknetSignature
 
@@ -286,7 +286,7 @@ public struct StarknetDeployAccountTransactionV1: StarknetDeployAccountTransacti
         self.contractAddressSalt = contractAddressSalt
         self.constructorCalldata = constructorCalldata
         self.classHash = classHash
-        self.version = StarknetDeployAccountTransactionV1.computeVersion(1, forFeeEstimation: forFeeEstimation)
+        self.version = forFeeEstimation ? .v1Query : .v1
         self.hash = hash
     }
 
@@ -298,7 +298,7 @@ public struct StarknetDeployAccountTransactionV1: StarknetDeployAccountTransacti
         self.contractAddressSalt = try container.decode(Felt.self, forKey: .contractAddressSalt)
         self.constructorCalldata = try container.decode(StarknetCalldata.self, forKey: .constructorCalldata)
         self.classHash = try container.decode(Felt.self, forKey: .classHash)
-        self.version = try container.decode(Felt.self, forKey: .version)
+        self.version = try container.decode(StarknetTransactionVersion.self, forKey: .version)
         self.hash = try container.decodeIfPresent(Felt.self, forKey: .hash)
 
         try verifyTransactionType(container: container, codingKeysType: CodingKeys.self)
@@ -320,7 +320,7 @@ public struct StarknetDeployAccountTransactionV1: StarknetDeployAccountTransacti
 public struct StarknetL1HandlerTransaction: StarknetTransaction {
     public let type: StarknetTransactionType = .l1Handler
 
-    public let version: Felt = .zero
+    public let version: StarknetTransactionVersion = .v0
 
     public let nonce: Felt
 
@@ -366,7 +366,7 @@ public struct StarknetL1HandlerTransaction: StarknetTransaction {
 public struct StarknetDeclareTransactionV3: StarknetDeclareTransaction, StarknetTransactionV3 {
     public let type: StarknetTransactionType = .declare
 
-    public let version: Felt = 3
+    public let version: StarknetTransactionVersion = .v3
 
     public let signature: StarknetSignature
 
@@ -452,7 +452,7 @@ public struct StarknetDeclareTransactionV0: StarknetDeclareTransaction, Starknet
 
     public let maxFee: Felt
 
-    public let version: Felt = .zero
+    public let version: StarknetTransactionVersion = .v0
 
     public let signature: StarknetSignature
 
@@ -498,7 +498,7 @@ public struct StarknetDeclareTransactionV1: StarknetDeclareTransaction, Starknet
 
     public let maxFee: Felt
 
-    public let version: Felt = .one
+    public let version: StarknetTransactionVersion = .v1
 
     public let signature: StarknetSignature
 
@@ -549,7 +549,7 @@ public struct StarknetDeclareTransactionV2: StarknetTransaction {
 
     public let maxFee: Felt
 
-    public let version: Felt = 2
+    public let version: StarknetTransactionVersion = .v2
 
     public let signature: StarknetSignature
 
@@ -603,7 +603,7 @@ public struct StarknetDeclareTransactionV2: StarknetTransaction {
 public struct StarknetDeployTransaction: StarknetTransaction {
     public let type: StarknetTransactionType = .deploy
 
-    public let version: Felt = .zero
+    public let version: StarknetTransactionVersion = .v0
 
     public let contractAddressSalt: Felt
 
@@ -650,10 +650,6 @@ extension StarknetExecutableTransaction {
     private static func estimateVersion(_ version: Felt) -> Felt {
         Felt(BigUInt(2).power(128).advanced(by: BigInt(version.value)))!
     }
-
-    static func computeVersion(_ version: Felt, forFeeEstimation: Bool) -> Felt {
-        forFeeEstimation ? estimateVersion(version) : version
-    }
 }
 
 // Default deserializer doesn't check if the fields with default values match what is deserialized.
@@ -668,7 +664,7 @@ extension StarknetTransaction {
     }
 
     func verifyTransactionVersion<T>(container: KeyedDecodingContainer<T>, codingKeysType _: T.Type) throws where T: CodingKey {
-        let version = try container.decode(Felt.self, forKey: T(stringValue: "version")!)
+        let version = try container.decode(StarknetTransactionVersion.self, forKey: T(stringValue: "version")!)
 
         guard version == self.version else {
             throw StarknetTransactionDecodingError.invalidVersion

--- a/Sources/Starknet/Data/Transaction/TransactionHash.swift
+++ b/Sources/Starknet/Data/Transaction/TransactionHash.swift
@@ -6,7 +6,7 @@ public class StarknetTransactionHashCalculator {
 
     private class func computeCommonDeprecatedTransactionHash(
         transactionType: StarknetTransactionType,
-        version: Felt,
+        version: StarknetTransactionVersion,
         contractAddress: Felt,
         entryPointSelector: Felt,
         calldata: StarknetCalldata,
@@ -16,7 +16,7 @@ public class StarknetTransactionHashCalculator {
     ) -> Felt {
         StarknetCurve.pedersenOn(
             transactionType.encodedValue,
-            version,
+            version.value,
             contractAddress,
             entryPointSelector,
             StarknetCurve.pedersenOn(calldata),
@@ -38,7 +38,7 @@ public class StarknetTransactionHashCalculator {
 
         return [
             transactionType.encodedValue,
-            version,
+            version.value,
             address,
             StarknetPoseidon.poseidonHash(
                 [tip.value.toFelt()!]

--- a/Sources/Starknet/Data/Transaction/TransactionProtocol.swift
+++ b/Sources/Starknet/Data/Transaction/TransactionProtocol.swift
@@ -35,6 +35,6 @@ public protocol StarknetExecutableTransaction: StarknetTransaction {}
 
 public protocol StarknetTransaction: Codable, Hashable, Equatable {
     var type: StarknetTransactionType { get }
-    var version: Felt { get }
+    var version: StarknetTransactionVersion { get }
     var hash: Felt? { get }
 }

--- a/Sources/Starknet/Data/Transaction/TransactionWrapper.swift
+++ b/Sources/Starknet/Data/Transaction/TransactionWrapper.swift
@@ -7,9 +7,9 @@ enum TransactionWrapper: Decodable {
         case version
     }
 
+    case invokeV3(StarknetInvokeTransactionV3)
     case invokeV1(StarknetInvokeTransactionV1)
     case invokeV0(StarknetInvokeTransactionV0)
-    case invokeV3(StarknetInvokeTransactionV3)
     case deployAccountV3(StarknetDeployAccountTransactionV3)
     case deployAccountV1(StarknetDeployAccountTransactionV1)
     case deploy(StarknetDeployTransaction)

--- a/Sources/Starknet/Data/Transaction/TransactionWrapper.swift
+++ b/Sources/Starknet/Data/Transaction/TransactionWrapper.swift
@@ -49,30 +49,30 @@ enum TransactionWrapper: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: Keys.self)
         let type = try container.decode(StarknetTransactionType.self, forKey: Keys.type)
-        let version = try container.decode(Felt.self, forKey: Keys.version)
+        let version = try container.decode(StarknetTransactionVersion.self, forKey: Keys.version)
 
         switch (type, version) {
-        case (.invoke, 3):
+        case (.invoke, .v3):
             self = try .invokeV3(StarknetInvokeTransactionV3(from: decoder))
-        case (.invoke, .one):
+        case (.invoke, .v1):
             self = try .invokeV1(StarknetInvokeTransactionV1(from: decoder))
-        case (.invoke, .zero):
+        case (.invoke, .v0):
             self = try .invokeV0(StarknetInvokeTransactionV0(from: decoder))
-        case (.deployAccount, 3):
+        case (.deployAccount, .v3):
             self = try .deployAccountV3(StarknetDeployAccountTransactionV3(from: decoder))
-        case (.deployAccount, .one):
+        case (.deployAccount, .v1):
             self = try .deployAccountV1(StarknetDeployAccountTransactionV1(from: decoder))
-        case (.declare, 3):
+        case (.declare, .v3):
             self = try .declareV3(StarknetDeclareTransactionV3(from: decoder))
-        case (.declare, 2):
+        case (.declare, .v2):
             self = try .declareV2(StarknetDeclareTransactionV2(from: decoder))
-        case (.declare, .one):
+        case (.declare, .v1):
             self = try .declareV1(StarknetDeclareTransactionV1(from: decoder))
-        case (.declare, .zero):
+        case (.declare, .v0):
             self = try .declareV0(StarknetDeclareTransactionV0(from: decoder))
-        case (.deploy, .zero):
+        case (.deploy, .v0):
             self = try .deploy(StarknetDeployTransaction(from: decoder))
-        case (.l1Handler, .zero):
+        case (.l1Handler, .v0):
             self = try .l1Handler(StarknetL1HandlerTransaction(from: decoder))
         default:
             throw DecodingError.dataCorruptedError(forKey: Keys.version, in: container, debugDescription: "Invalid transaction version (\(version) for transaction type (\(type))")

--- a/Tests/StarknetTests/Data/TransactionTests.swift
+++ b/Tests/StarknetTests/Data/TransactionTests.swift
@@ -71,21 +71,21 @@ final class TransactionTests: XCTestCase {
     }
 
     func testTransactionWrapperDecoding() throws {
-        let cases: [(String, StarknetTransactionType, Felt)] = [
-            (invokeTransactionV3, .invoke, 3),
-            (invokeTransactionV1, .invoke, 1),
-            (invokeTransactionV0, .invoke, 0),
-            (declareTransactinoV0, .declare, 0),
-            (declareTransactionV1, .declare, 1),
-            (declareTransactionV2, .declare, 2),
-            (declareTransactionV3, .declare, 3),
-            (deployTransaction, .deploy, 0),
-            (deployAccountTransactionV1, .deployAccount, 1),
-            (deployAccountTransactionV3, .deployAccount, 3),
-            (l1HandlerTransaction, .l1Handler, 0),
+        let cases: [(String, StarknetTransactionType, StarknetTransactionVersion)] = [
+            (invokeTransactionV3, .invoke, .v3),
+            (invokeTransactionV1, .invoke, .v1),
+            (invokeTransactionV0, .invoke, .v0),
+            (declareTransactinoV0, .declare, .v0),
+            (declareTransactionV1, .declare, .v1),
+            (declareTransactionV2, .declare, .v2),
+            (declareTransactionV3, .declare, .v3),
+            (deployTransaction, .deploy, .v0),
+            (deployAccountTransactionV1, .deployAccount, .v1),
+            (deployAccountTransactionV3, .deployAccount, .v3),
+            (l1HandlerTransaction, .l1Handler, .v0),
         ]
 
-        try cases.forEach { (string: String, type: StarknetTransactionType, version: Felt) in
+        try cases.forEach { (string: String, type: StarknetTransactionType, version: StarknetTransactionVersion) in
             let data = string.data(using: .utf8)!
 
             let decoder = JSONDecoder()


### PR DESCRIPTION
## Stack

-- Support RPC 0.7.0 (#162)
-- Add `execute` methods with custom fee multipliers (#163) 
-- Add transaction version enum (#164)
-- Refactor receipts (#165)

## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

As all the tx versions are enums in the 0.7 spec, use enums instead of raw values in the SDK

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [x] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
- `version` of `StarknetTransaction` is now of type `StarknetTransactionVersion` instead of `Felt`; This applies to all derived transaction structs