### PR TITLE
Refactor receipts

### DIFF
--- a/Sources/Starknet/Data/Transaction/TransactionReceipt.swift
+++ b/Sources/Starknet/Data/Transaction/TransactionReceipt.swift
@@ -1,75 +1,17 @@
 import Foundation
 
-public struct StarknetInvokeTransactionReceiptWithBlockInfo: StarknetTransactionReceiptWithBlockInfo, StarknetInvokeTransactionReceiptProtocol {
-    public let transactionHash: Felt
-    public let actualFee: StarknetFeePayment
-    public let blockHash: Felt
-    public let blockNumber: UInt64
-    public let messagesSent: [StarknetMessageToL1]
-    public let events: [StarknetEvent]
-    public let revertReason: String?
-    public let finalityStatus: StarknetTransactionFinalityStatus
-    public let executionStatus: StarknetTransactionExecutionStatus
-    public let executionResources: StarknetExecutionResources
-    public let type: StarknetTransactionType = .invoke
-
-    public var isSuccessful: Bool {
-        executionStatus == .succeeded && (finalityStatus == .acceptedL1 || finalityStatus == .acceptedL2)
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case transactionHash = "transaction_hash"
-        case actualFee = "actual_fee"
-        case blockHash = "block_hash"
-        case blockNumber = "block_number"
-        case messagesSent = "messages_sent"
-        case events
-        case finalityStatus = "finality_status"
-        case executionStatus = "execution_status"
-        case revertReason = "revert_reason"
-        case executionResources = "execution_resources"
-    }
-}
-
 public struct StarknetInvokeTransactionReceipt: StarknetInvokeTransactionReceiptProtocol {
     public let transactionHash: Felt
     public let actualFee: StarknetFeePayment
-    public let messagesSent: [StarknetMessageToL1]
-    public let events: [StarknetEvent]
-    public let executionStatus: StarknetTransactionExecutionStatus
-    public let finalityStatus: StarknetTransactionFinalityStatus
-    public var executionResources: StarknetExecutionResources
-    public let revertReason: String?
-    public let type: StarknetTransactionType = .invoke
-
-    public var isSuccessful: Bool {
-        executionStatus == .succeeded && (finalityStatus == .acceptedL1 || finalityStatus == .acceptedL2)
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case transactionHash = "transaction_hash"
-        case actualFee = "actual_fee"
-        case messagesSent = "messages_sent"
-        case events
-        case finalityStatus = "finality_status"
-        case executionStatus = "execution_status"
-        case executionResources = "execution_resources"
-        case revertReason = "revert_reason"
-    }
-}
-
-public struct StarknetDeclareTransactionReceiptWithBlockInfo: StarknetTransactionReceiptWithBlockInfo, StarknetDeclareTransactionReceiptProtocol {
-    public let transactionHash: Felt
-    public let actualFee: StarknetFeePayment
-    public let blockHash: Felt
-    public let blockNumber: UInt64
+    public let blockHash: Felt?
+    public let blockNumber: UInt64?
     public let messagesSent: [StarknetMessageToL1]
     public let events: [StarknetEvent]
     public let revertReason: String?
     public let finalityStatus: StarknetTransactionFinalityStatus
     public let executionStatus: StarknetTransactionExecutionStatus
     public let executionResources: StarknetExecutionResources
-    public let type: StarknetTransactionType = .declare
+    public let type: StarknetTransactionType = .invoke
 
     public var isSuccessful: Bool {
         executionStatus == .succeeded && (finalityStatus == .acceptedL1 || finalityStatus == .acceptedL2)
@@ -92,12 +34,14 @@ public struct StarknetDeclareTransactionReceiptWithBlockInfo: StarknetTransactio
 public struct StarknetDeclareTransactionReceipt: StarknetDeclareTransactionReceiptProtocol {
     public let transactionHash: Felt
     public let actualFee: StarknetFeePayment
+    public let blockHash: Felt?
+    public let blockNumber: UInt64?
     public let messagesSent: [StarknetMessageToL1]
     public let events: [StarknetEvent]
-    public let executionStatus: StarknetTransactionExecutionStatus
-    public let finalityStatus: StarknetTransactionFinalityStatus
-    public var executionResources: StarknetExecutionResources
     public let revertReason: String?
+    public let finalityStatus: StarknetTransactionFinalityStatus
+    public let executionStatus: StarknetTransactionExecutionStatus
+    public let executionResources: StarknetExecutionResources
     public let type: StarknetTransactionType = .declare
 
     public var isSuccessful: Bool {
@@ -107,20 +51,22 @@ public struct StarknetDeclareTransactionReceipt: StarknetDeclareTransactionRecei
     enum CodingKeys: String, CodingKey {
         case transactionHash = "transaction_hash"
         case actualFee = "actual_fee"
+        case blockHash = "block_hash"
+        case blockNumber = "block_number"
         case messagesSent = "messages_sent"
         case events
         case finalityStatus = "finality_status"
         case executionStatus = "execution_status"
-        case executionResources = "execution_resources"
         case revertReason = "revert_reason"
+        case executionResources = "execution_resources"
     }
 }
 
-public struct StarknetDeployAccountTransactionReceiptWithBlockInfo: StarknetTransactionReceiptWithBlockInfo, StarknetDeployAccountTransactionReceiptProtocol {
+public struct StarknetDeployAccountTransactionReceipt: StarknetDeployAccountTransactionReceiptProtocol {
     public let transactionHash: Felt
     public let actualFee: StarknetFeePayment
-    public let blockHash: Felt
-    public let blockNumber: UInt64
+    public let blockHash: Felt?
+    public let blockNumber: UInt64?
     public let messagesSent: [StarknetMessageToL1]
     public let events: [StarknetEvent]
     public let revertReason: String?
@@ -145,35 +91,6 @@ public struct StarknetDeployAccountTransactionReceiptWithBlockInfo: StarknetTran
         case executionStatus = "execution_status"
         case revertReason = "revert_reason"
         case executionResources = "execution_resources"
-        case contractAddress = "contract_address"
-    }
-}
-
-public struct StarknetDeployAccountTransactionReceipt: StarknetDeployAccountTransactionReceiptProtocol {
-    public let transactionHash: Felt
-    public let actualFee: StarknetFeePayment
-    public let messagesSent: [StarknetMessageToL1]
-    public let events: [StarknetEvent]
-    public let executionStatus: StarknetTransactionExecutionStatus
-    public let finalityStatus: StarknetTransactionFinalityStatus
-    public var executionResources: StarknetExecutionResources
-    public let revertReason: String?
-    public let contractAddress: Felt
-    public let type: StarknetTransactionType = .deployAccount
-
-    public var isSuccessful: Bool {
-        executionStatus == .succeeded && (finalityStatus == .acceptedL1 || finalityStatus == .acceptedL2)
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case transactionHash = "transaction_hash"
-        case actualFee = "actual_fee"
-        case messagesSent = "messages_sent"
-        case events
-        case finalityStatus = "finality_status"
-        case executionStatus = "execution_status"
-        case executionResources = "execution_resources"
-        case revertReason = "revert_reason"
         case contractAddress = "contract_address"
     }
 }
@@ -181,37 +98,8 @@ public struct StarknetDeployAccountTransactionReceipt: StarknetDeployAccountTran
 public struct StarknetDeployTransactionReceipt: StarknetDeployTransactionReceiptProtocol {
     public let transactionHash: Felt
     public let actualFee: StarknetFeePayment
-    public let messagesSent: [StarknetMessageToL1]
-    public let events: [StarknetEvent]
-    public let revertReason: String?
-    public let finalityStatus: StarknetTransactionFinalityStatus
-    public let executionStatus: StarknetTransactionExecutionStatus
-    public let executionResources: StarknetExecutionResources
-    public let contractAddress: Felt
-    public let type: StarknetTransactionType = .deploy
-
-    public var isSuccessful: Bool {
-        executionStatus == .succeeded && (finalityStatus == .acceptedL1 || finalityStatus == .acceptedL2)
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case transactionHash = "transaction_hash"
-        case actualFee = "actual_fee"
-        case messagesSent = "messages_sent"
-        case events
-        case finalityStatus = "finality_status"
-        case executionStatus = "execution_status"
-        case revertReason = "revert_reason"
-        case executionResources = "execution_resources"
-        case contractAddress = "contract_address"
-    }
-}
-
-public struct StarknetDeployTransactionReceiptWithBlockInfo: StarknetTransactionReceiptWithBlockInfo, StarknetDeployTransactionReceiptProtocol {
-    public let transactionHash: Felt
-    public let actualFee: StarknetFeePayment
-    public let blockHash: Felt
-    public let blockNumber: UInt64
+    public let blockHash: Felt?
+    public let blockNumber: UInt64?
     public let messagesSent: [StarknetMessageToL1]
     public let events: [StarknetEvent]
     public let revertReason: String?
@@ -237,51 +125,20 @@ public struct StarknetDeployTransactionReceiptWithBlockInfo: StarknetTransaction
         case revertReason = "revert_reason"
         case executionResources = "execution_resources"
         case contractAddress = "contract_address"
-    }
-}
-
-public struct StarknetL1HandlerTransactionReceiptWithBlockInfo: StarknetTransactionReceiptWithBlockInfo, StarknetL1HandlerTransactionReceiptProtocol {
-    public let transactionHash: Felt
-    public let actualFee: StarknetFeePayment
-    public let blockHash: Felt
-    public let blockNumber: UInt64
-    public let messagesSent: [StarknetMessageToL1]
-    public let events: [StarknetEvent]
-    public let revertReason: String?
-    public let finalityStatus: StarknetTransactionFinalityStatus
-    public let executionStatus: StarknetTransactionExecutionStatus
-    public let executionResources: StarknetExecutionResources
-    public let messageHash: NumAsHex
-    public let type: StarknetTransactionType = .l1Handler
-
-    public var isSuccessful: Bool {
-        executionStatus == .succeeded && (finalityStatus == .acceptedL1 || finalityStatus == .acceptedL2)
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case transactionHash = "transaction_hash"
-        case actualFee = "actual_fee"
-        case blockHash = "block_hash"
-        case blockNumber = "block_number"
-        case messagesSent = "messages_sent"
-        case events
-        case finalityStatus = "finality_status"
-        case executionStatus = "execution_status"
-        case revertReason = "revert_reason"
-        case executionResources = "execution_resources"
-        case messageHash = "message_hash"
     }
 }
 
 public struct StarknetL1HandlerTransactionReceipt: StarknetL1HandlerTransactionReceiptProtocol {
     public let transactionHash: Felt
     public let actualFee: StarknetFeePayment
+    public let blockHash: Felt?
+    public let blockNumber: UInt64?
     public let messagesSent: [StarknetMessageToL1]
     public let events: [StarknetEvent]
-    public let executionStatus: StarknetTransactionExecutionStatus
-    public let finalityStatus: StarknetTransactionFinalityStatus
-    public var executionResources: StarknetExecutionResources
     public let revertReason: String?
+    public let finalityStatus: StarknetTransactionFinalityStatus
+    public let executionStatus: StarknetTransactionExecutionStatus
+    public let executionResources: StarknetExecutionResources
     public let messageHash: NumAsHex
     public let type: StarknetTransactionType = .l1Handler
 
@@ -292,12 +149,14 @@ public struct StarknetL1HandlerTransactionReceipt: StarknetL1HandlerTransactionR
     enum CodingKeys: String, CodingKey {
         case transactionHash = "transaction_hash"
         case actualFee = "actual_fee"
+        case blockHash = "block_hash"
+        case blockNumber = "block_number"
         case messagesSent = "messages_sent"
         case events
         case finalityStatus = "finality_status"
         case executionStatus = "execution_status"
-        case executionResources = "execution_resources"
         case revertReason = "revert_reason"
+        case executionResources = "execution_resources"
         case messageHash = "message_hash"
     }
 }

--- a/Sources/Starknet/Data/Transaction/TransactionReceipt.swift
+++ b/Sources/Starknet/Data/Transaction/TransactionReceipt.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct StarknetProcessedInvokeTransactionReceipt: StarknetProcessedTransactionReceipt, StarknetInvokeTransactionReceipt {
+public struct StarknetInvokeTransactionReceiptWithBlockInfo: StarknetTransactionReceiptWithBlockInfo, StarknetInvokeTransactionReceiptProtocol {
     public let transactionHash: Felt
     public let actualFee: StarknetFeePayment
     public let blockHash: Felt
@@ -31,7 +31,7 @@ public struct StarknetProcessedInvokeTransactionReceipt: StarknetProcessedTransa
     }
 }
 
-public struct StarknetPendingInvokeTransactionReceipt: StarknetPendingTransactionReceipt, StarknetInvokeTransactionReceipt {
+public struct StarknetInvokeTransactionReceipt: StarknetInvokeTransactionReceiptProtocol {
     public let transactionHash: Felt
     public let actualFee: StarknetFeePayment
     public let messagesSent: [StarknetMessageToL1]
@@ -58,7 +58,7 @@ public struct StarknetPendingInvokeTransactionReceipt: StarknetPendingTransactio
     }
 }
 
-public struct StarknetProcessedDeclareTransactionReceipt: StarknetProcessedTransactionReceipt, StarknetDeclareTransactionReceipt {
+public struct StarknetDeclareTransactionReceiptWithBlockInfo: StarknetTransactionReceiptWithBlockInfo, StarknetDeclareTransactionReceiptProtocol {
     public let transactionHash: Felt
     public let actualFee: StarknetFeePayment
     public let blockHash: Felt
@@ -89,7 +89,7 @@ public struct StarknetProcessedDeclareTransactionReceipt: StarknetProcessedTrans
     }
 }
 
-public struct StarknetPendingDeclareTransactionReceipt: StarknetPendingTransactionReceipt, StarknetDeclareTransactionReceipt {
+public struct StarknetDeclareTransactionReceipt: StarknetDeclareTransactionReceiptProtocol {
     public let transactionHash: Felt
     public let actualFee: StarknetFeePayment
     public let messagesSent: [StarknetMessageToL1]
@@ -116,7 +116,7 @@ public struct StarknetPendingDeclareTransactionReceipt: StarknetPendingTransacti
     }
 }
 
-public struct StarknetProcessedDeployAccountTransactionReceipt: StarknetProcessedTransactionReceipt, StarknetDeployAccountTransactionReceipt {
+public struct StarknetDeployAccountTransactionReceiptWithBlockInfo: StarknetTransactionReceiptWithBlockInfo, StarknetDeployAccountTransactionReceiptProtocol {
     public let transactionHash: Felt
     public let actualFee: StarknetFeePayment
     public let blockHash: Felt
@@ -149,7 +149,7 @@ public struct StarknetProcessedDeployAccountTransactionReceipt: StarknetProcesse
     }
 }
 
-public struct StarknetPendingDeployAccountTransactionReceipt: StarknetPendingTransactionReceipt, StarknetDeployAccountTransactionReceipt {
+public struct StarknetDeployAccountTransactionReceipt: StarknetDeployAccountTransactionReceiptProtocol {
     public let transactionHash: Felt
     public let actualFee: StarknetFeePayment
     public let messagesSent: [StarknetMessageToL1]
@@ -178,7 +178,36 @@ public struct StarknetPendingDeployAccountTransactionReceipt: StarknetPendingTra
     }
 }
 
-public struct StarknetProcessedDeployTransactionReceipt: StarknetProcessedTransactionReceipt, StarknetDeployTransactionReceipt {
+public struct StarknetDeployTransactionReceipt: StarknetDeployTransactionReceiptProtocol {
+    public let transactionHash: Felt
+    public let actualFee: StarknetFeePayment
+    public let messagesSent: [StarknetMessageToL1]
+    public let events: [StarknetEvent]
+    public let revertReason: String?
+    public let finalityStatus: StarknetTransactionFinalityStatus
+    public let executionStatus: StarknetTransactionExecutionStatus
+    public let executionResources: StarknetExecutionResources
+    public let contractAddress: Felt
+    public let type: StarknetTransactionType = .deploy
+
+    public var isSuccessful: Bool {
+        executionStatus == .succeeded && (finalityStatus == .acceptedL1 || finalityStatus == .acceptedL2)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case transactionHash = "transaction_hash"
+        case actualFee = "actual_fee"
+        case messagesSent = "messages_sent"
+        case events
+        case finalityStatus = "finality_status"
+        case executionStatus = "execution_status"
+        case revertReason = "revert_reason"
+        case executionResources = "execution_resources"
+        case contractAddress = "contract_address"
+    }
+}
+
+public struct StarknetDeployTransactionReceiptWithBlockInfo: StarknetTransactionReceiptWithBlockInfo, StarknetDeployTransactionReceiptProtocol {
     public let transactionHash: Felt
     public let actualFee: StarknetFeePayment
     public let blockHash: Felt
@@ -211,7 +240,7 @@ public struct StarknetProcessedDeployTransactionReceipt: StarknetProcessedTransa
     }
 }
 
-public struct StarknetProcessedL1HandlerTransactionReceipt: StarknetProcessedTransactionReceipt, StarknetL1HandlerTransactionReceipt {
+public struct StarknetL1HandlerTransactionReceiptWithBlockInfo: StarknetTransactionReceiptWithBlockInfo, StarknetL1HandlerTransactionReceiptProtocol {
     public let transactionHash: Felt
     public let actualFee: StarknetFeePayment
     public let blockHash: Felt
@@ -244,7 +273,7 @@ public struct StarknetProcessedL1HandlerTransactionReceipt: StarknetProcessedTra
     }
 }
 
-public struct StarknetPendingL1HandlerTransactionReceipt: StarknetPendingTransactionReceipt, StarknetL1HandlerTransactionReceipt {
+public struct StarknetL1HandlerTransactionReceipt: StarknetL1HandlerTransactionReceiptProtocol {
     public let transactionHash: Felt
     public let actualFee: StarknetFeePayment
     public let messagesSent: [StarknetMessageToL1]

--- a/Sources/Starknet/Data/Transaction/TransactionReceiptProtocol.swift
+++ b/Sources/Starknet/Data/Transaction/TransactionReceiptProtocol.swift
@@ -1,27 +1,25 @@
 import Foundation
 
-public protocol StarknetInvokeTransactionReceipt: StarknetTransactionReceipt {}
+public protocol StarknetInvokeTransactionReceiptProtocol: StarknetTransactionReceipt {}
 
-public protocol StarknetDeclareTransactionReceipt: StarknetTransactionReceipt {}
+public protocol StarknetDeclareTransactionReceiptProtocol: StarknetTransactionReceipt {}
 
-public protocol StarknetDeployTransactionReceipt: StarknetTransactionReceipt {
+public protocol StarknetDeployTransactionReceiptProtocol: StarknetTransactionReceipt {
     var contractAddress: Felt { get }
 }
 
-public protocol StarknetDeployAccountTransactionReceipt: StarknetTransactionReceipt {
+public protocol StarknetDeployAccountTransactionReceiptProtocol: StarknetTransactionReceipt {
     var contractAddress: Felt { get }
 }
 
-public protocol StarknetL1HandlerTransactionReceipt: StarknetTransactionReceipt {
+public protocol StarknetL1HandlerTransactionReceiptProtocol: StarknetTransactionReceipt {
     var messageHash: NumAsHex { get }
 }
 
-public protocol StarknetProcessedTransactionReceipt: StarknetTransactionReceipt {
+public protocol StarknetTransactionReceiptWithBlockInfo: StarknetTransactionReceipt {
     var blockHash: Felt { get }
     var blockNumber: UInt64 { get }
 }
-
-public protocol StarknetPendingTransactionReceipt: StarknetTransactionReceipt {}
 
 public protocol StarknetTransactionReceipt: Decodable, Equatable {
     var transactionHash: Felt { get }

--- a/Sources/Starknet/Data/Transaction/TransactionReceiptProtocol.swift
+++ b/Sources/Starknet/Data/Transaction/TransactionReceiptProtocol.swift
@@ -16,11 +16,6 @@ public protocol StarknetL1HandlerTransactionReceiptProtocol: StarknetTransaction
     var messageHash: NumAsHex { get }
 }
 
-public protocol StarknetTransactionReceiptWithBlockInfo: StarknetTransactionReceipt {
-    var blockHash: Felt { get }
-    var blockNumber: UInt64 { get }
-}
-
 public protocol StarknetTransactionReceipt: Decodable, Equatable {
     var transactionHash: Felt { get }
     var actualFee: StarknetFeePayment { get }
@@ -31,6 +26,9 @@ public protocol StarknetTransactionReceipt: Decodable, Equatable {
     var executionResources: StarknetExecutionResources { get }
     var revertReason: String? { get }
     var type: StarknetTransactionType { get }
+    // Block info
+    var blockHash: Felt? { get }
+    var blockNumber: UInt64? { get }
 
     var isSuccessful: Bool { get }
 }

--- a/Sources/Starknet/Data/Transaction/TransactionReceiptWrapper.swift
+++ b/Sources/Starknet/Data/Transaction/TransactionReceiptWrapper.swift
@@ -2,16 +2,9 @@ import Foundation
 
 enum TransactionReceiptWrapper: Decodable {
     fileprivate enum Keys: String, CodingKey {
-        case blockHash = "block_hash"
-        case blockNumber = "block_number"
         case type
     }
 
-    case invokeBlockInfo(StarknetInvokeTransactionReceiptWithBlockInfo)
-    case declareBlockInfo(StarknetDeclareTransactionReceiptWithBlockInfo)
-    case deployAccountBlockInfo(StarknetDeployAccountTransactionReceiptWithBlockInfo)
-    case l1HandlerBlockInfo(StarknetL1HandlerTransactionReceiptWithBlockInfo)
-    case deployBlockInfo(StarknetDeployTransactionReceiptWithBlockInfo)
     case invoke(StarknetInvokeTransactionReceipt)
     case declare(StarknetDeclareTransactionReceipt)
     case deployAccount(StarknetDeployAccountTransactionReceipt)
@@ -20,16 +13,6 @@ enum TransactionReceiptWrapper: Decodable {
 
     public var transactionReceipt: any StarknetTransactionReceipt {
         switch self {
-        case let .invokeBlockInfo(tx):
-            return tx
-        case let .declareBlockInfo(tx):
-            return tx
-        case let .deployAccountBlockInfo(tx):
-            return tx
-        case let .l1HandlerBlockInfo(tx):
-            return tx
-        case let .deployBlockInfo(tx):
-            return tx
         case let .invoke(tx):
             return tx
         case let .declare(tx):
@@ -47,31 +30,17 @@ enum TransactionReceiptWrapper: Decodable {
         let container = try decoder.container(keyedBy: Keys.self)
 
         let type = try container.decode(StarknetTransactionType.self, forKey: Keys.type)
-        let blockHash = try container.decodeIfPresent(Felt.self, forKey: Keys.blockHash)
-        let blockNumber = try container.decodeIfPresent(Felt.self, forKey: Keys.blockHash)
 
-        let hasBlockInfo = blockHash != nil && blockNumber != nil
-
-        switch (type, hasBlockInfo) {
-        case (.invoke, true):
-            self = try .invokeBlockInfo(StarknetInvokeTransactionReceiptWithBlockInfo(from: decoder))
-        case (.declare, true):
-            self = try .declareBlockInfo(StarknetDeclareTransactionReceiptWithBlockInfo(from: decoder))
-        case (.deployAccount, true):
-            self = try .deployAccountBlockInfo(StarknetDeployAccountTransactionReceiptWithBlockInfo(from: decoder))
-        case (.l1Handler, true):
-            self = try .l1HandlerBlockInfo(StarknetL1HandlerTransactionReceiptWithBlockInfo(from: decoder))
-        case (.deploy, true):
-            self = try .deployBlockInfo(StarknetDeployTransactionReceiptWithBlockInfo(from: decoder))
-        case (.invoke, false):
+        switch type {
+        case .invoke:
             self = try .invoke(StarknetInvokeTransactionReceipt(from: decoder))
-        case (.declare, false):
-            self = try .declare(StarknetDeclareTransactionReceipt(from: decoder))
-        case (.deployAccount, false):
+        case .deployAccount:
             self = try .deployAccount(StarknetDeployAccountTransactionReceipt(from: decoder))
-        case (.l1Handler, false):
+        case .declare:
+            self = try .declare(StarknetDeclareTransactionReceipt(from: decoder))
+        case .l1Handler:
             self = try .l1Handler(StarknetL1HandlerTransactionReceipt(from: decoder))
-        case (.deploy, false):
+        case .deploy:
             self = try .deploy(StarknetDeployTransactionReceipt(from: decoder))
         }
     }

--- a/Sources/Starknet/Data/Transaction/TransactionReceiptWrapper.swift
+++ b/Sources/Starknet/Data/Transaction/TransactionReceiptWrapper.swift
@@ -7,18 +7,29 @@ enum TransactionReceiptWrapper: Decodable {
         case type
     }
 
-    case invoke(StarknetProcessedInvokeTransactionReceipt)
-    case declare(StarknetProcessedDeclareTransactionReceipt)
-    case deployAccount(StarknetProcessedDeployAccountTransactionReceipt)
-    case l1Handler(StarknetProcessedL1HandlerTransactionReceipt)
-    case deploy(StarknetProcessedDeployTransactionReceipt)
-    case pendingInvoke(StarknetPendingInvokeTransactionReceipt)
-    case pendingDeclare(StarknetPendingDeclareTransactionReceipt)
-    case pendingDeployAccount(StarknetPendingDeployAccountTransactionReceipt)
-    case pendingL1Handler(StarknetPendingL1HandlerTransactionReceipt)
+    case invokeBlockInfo(StarknetInvokeTransactionReceiptWithBlockInfo)
+    case declareBlockInfo(StarknetDeclareTransactionReceiptWithBlockInfo)
+    case deployAccountBlockInfo(StarknetDeployAccountTransactionReceiptWithBlockInfo)
+    case l1HandlerBlockInfo(StarknetL1HandlerTransactionReceiptWithBlockInfo)
+    case deployBlockInfo(StarknetDeployTransactionReceiptWithBlockInfo)
+    case invoke(StarknetInvokeTransactionReceipt)
+    case declare(StarknetDeclareTransactionReceipt)
+    case deployAccount(StarknetDeployAccountTransactionReceipt)
+    case l1Handler(StarknetL1HandlerTransactionReceipt)
+    case deploy(StarknetDeployTransactionReceipt)
 
     public var transactionReceipt: any StarknetTransactionReceipt {
         switch self {
+        case let .invokeBlockInfo(tx):
+            return tx
+        case let .declareBlockInfo(tx):
+            return tx
+        case let .deployAccountBlockInfo(tx):
+            return tx
+        case let .l1HandlerBlockInfo(tx):
+            return tx
+        case let .deployBlockInfo(tx):
+            return tx
         case let .invoke(tx):
             return tx
         case let .declare(tx):
@@ -28,14 +39,6 @@ enum TransactionReceiptWrapper: Decodable {
         case let .l1Handler(tx):
             return tx
         case let .deploy(tx):
-            return tx
-        case let .pendingInvoke(tx):
-            return tx
-        case let .pendingDeclare(tx):
-            return tx
-        case let .pendingDeployAccount(tx):
-            return tx
-        case let .pendingL1Handler(tx):
             return tx
         }
     }
@@ -47,29 +50,29 @@ enum TransactionReceiptWrapper: Decodable {
         let blockHash = try container.decodeIfPresent(Felt.self, forKey: Keys.blockHash)
         let blockNumber = try container.decodeIfPresent(Felt.self, forKey: Keys.blockHash)
 
-        let isPending = blockHash == nil || blockNumber == nil
+        let hasBlockInfo = blockHash != nil && blockNumber != nil
 
-        switch (type, isPending) {
-        case (.invoke, false):
-            self = try .invoke(StarknetProcessedInvokeTransactionReceipt(from: decoder))
-        case (.declare, false):
-            self = try .declare(StarknetProcessedDeclareTransactionReceipt(from: decoder))
-        case (.deployAccount, false):
-            self = try .deployAccount(StarknetProcessedDeployAccountTransactionReceipt(from: decoder))
-        case (.l1Handler, false):
-            self = try .l1Handler(StarknetProcessedL1HandlerTransactionReceipt(from: decoder))
-        case (.deploy, false):
-            self = try .deploy(StarknetProcessedDeployTransactionReceipt(from: decoder))
+        switch (type, hasBlockInfo) {
         case (.invoke, true):
-            self = try .pendingInvoke(StarknetPendingInvokeTransactionReceipt(from: decoder))
+            self = try .invokeBlockInfo(StarknetInvokeTransactionReceiptWithBlockInfo(from: decoder))
         case (.declare, true):
-            self = try .pendingDeclare(StarknetPendingDeclareTransactionReceipt(from: decoder))
+            self = try .declareBlockInfo(StarknetDeclareTransactionReceiptWithBlockInfo(from: decoder))
         case (.deployAccount, true):
-            self = try .pendingDeployAccount(StarknetPendingDeployAccountTransactionReceipt(from: decoder))
+            self = try .deployAccountBlockInfo(StarknetDeployAccountTransactionReceiptWithBlockInfo(from: decoder))
         case (.l1Handler, true):
-            self = try .pendingL1Handler(StarknetPendingL1HandlerTransactionReceipt(from: decoder))
-        default:
-            throw DecodingError.dataCorruptedError(forKey: Keys.type, in: container, debugDescription: "Invalid transaction receipt type (\(isPending ? "pending" : "") \(type))")
+            self = try .l1HandlerBlockInfo(StarknetL1HandlerTransactionReceiptWithBlockInfo(from: decoder))
+        case (.deploy, true):
+            self = try .deployBlockInfo(StarknetDeployTransactionReceiptWithBlockInfo(from: decoder))
+        case (.invoke, false):
+            self = try .invoke(StarknetInvokeTransactionReceipt(from: decoder))
+        case (.declare, false):
+            self = try .declare(StarknetDeclareTransactionReceipt(from: decoder))
+        case (.deployAccount, false):
+            self = try .deployAccount(StarknetDeployAccountTransactionReceipt(from: decoder))
+        case (.l1Handler, false):
+            self = try .l1Handler(StarknetL1HandlerTransactionReceipt(from: decoder))
+        case (.deploy, false):
+            self = try .deploy(StarknetDeployTransactionReceipt(from: decoder))
         }
     }
 }

--- a/Tests/StarknetTests/Data/TransactionReceiptTests.swift
+++ b/Tests/StarknetTests/Data/TransactionReceiptTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import Starknet
 
-let invokeReceipt = """
+let invokeReceiptWithBlockInfo = """
 {
     "type": "INVOKE",
     "transaction_hash": "0x333198614194ae5b5ef921e63898a592de5e9f4d7b6e04745093da88b429f2a",
@@ -19,7 +19,7 @@ let invokeReceipt = """
     "execution_resources": {"steps": 999, "memory_holes" : 1, "range_check_builtin_applications": 21, "pedersen_builtin_applications": 37, "poseidon_builtin_applications": 451, "ec_op_builtin_applications": 123, "ecdsa_builtin_applications": 789, "bitwise_builtin_applications": 1, "keccak_builtin_applications": 1, "data_availability": {"l1_gas": 123, "l1_data_gas": 456}}
 }
 """
-let pendingInvokeReceipt = """
+let invokeReceipt = """
 {
     "type": "INVOKE",
     "transaction_hash": "0x333198614194ae5b5ef921e63898a592de5e9f4d7b6e04745093da88b429f2a",
@@ -27,6 +27,23 @@ let pendingInvokeReceipt = """
                     "amount": "0x244adfc7e22",
                     "unit": "FRI"
                 },
+    "messages_sent": [],
+    "events": [],
+    "execution_status": "SUCCEEDED",
+    "finality_status": "ACCEPTED_ON_L2",
+    "execution_resources": {"steps": 999, "memory_holes" : 1, "range_check_builtin_applications": 21, "pedersen_builtin_applications": 37, "poseidon_builtin_applications": 451, "ec_op_builtin_applications": 123, "ecdsa_builtin_applications": 789, "bitwise_builtin_applications": 1, "keccak_builtin_applications": 1, "data_availability": {"l1_gas": 123, "l1_data_gas": 456}}
+}
+"""
+let declareReceiptWithBlockInfo = """
+{
+    "type": "DECLARE",
+    "transaction_hash": "0x333198614194ae5b5ef921e63898a592de5e9f4d7b6e04745093da88b429f2a",
+    "actual_fee": {
+                    "amount": "0x244adfc7e22",
+                    "unit": "FRI"
+                },
+    "block_hash": "0x3e1833c6f0bd56a041e150f74e2f5026157d8d3d890ab386eac58c9776da284",
+    "block_number": 308391,
     "messages_sent": [],
     "events": [],
     "execution_status": "SUCCEEDED",
@@ -42,23 +59,6 @@ let declareReceipt = """
                     "amount": "0x244adfc7e22",
                     "unit": "FRI"
                 },
-    "block_hash": "0x3e1833c6f0bd56a041e150f74e2f5026157d8d3d890ab386eac58c9776da284",
-    "block_number": 308391,
-    "messages_sent": [],
-    "events": [],
-    "execution_status": "SUCCEEDED",
-    "finality_status": "ACCEPTED_ON_L2",
-    "execution_resources": {"steps": 999, "memory_holes" : 1, "range_check_builtin_applications": 21, "pedersen_builtin_applications": 37, "poseidon_builtin_applications": 451, "ec_op_builtin_applications": 123, "ecdsa_builtin_applications": 789, "bitwise_builtin_applications": 1, "keccak_builtin_applications": 1, "data_availability": {"l1_gas": 123, "l1_data_gas": 456}}
-}
-"""
-let pendingDeclareReceipt = """
-{
-    "type": "DECLARE",
-    "transaction_hash": "0x333198614194ae5b5ef921e63898a592de5e9f4d7b6e04745093da88b429f2a",
-    "actual_fee": {
-                    "amount": "0x244adfc7e22",
-                    "unit": "FRI"
-                },
 	"messages_sent": [],
     "events": [],
     "execution_status": "SUCCEEDED",
@@ -66,7 +66,7 @@ let pendingDeclareReceipt = """
     "execution_resources": {"steps": 999, "memory_holes" : 1, "range_check_builtin_applications": 21, "pedersen_builtin_applications": 37, "poseidon_builtin_applications": 451, "ec_op_builtin_applications": 123, "ecdsa_builtin_applications": 789, "bitwise_builtin_applications": 1, "keccak_builtin_applications": 1, "data_availability": {"l1_gas": 123, "l1_data_gas": 456}}
 }
 """
-let deployAccountReceipt = """
+let deployAccountReceiptWithBlockInfo = """
 {
     "type": "DEPLOY_ACCOUNT",
     "transaction_hash": "0x333198614194ae5b5ef921e63898a592de5e9f4d7b6e04745093da88b429f2a",
@@ -84,7 +84,7 @@ let deployAccountReceipt = """
     "contract_address": "0x789"
 }
 """
-let pendingDeployAccountReceipt = """
+let deployAccountReceipt = """
 {
     "type": "DEPLOY_ACCOUNT",
     "transaction_hash": "0x333198614194ae5b5ef921e63898a592de5e9f4d7b6e04745093da88b429f2a",
@@ -100,7 +100,7 @@ let pendingDeployAccountReceipt = """
     "contract_address": "0x789"
 }
 """
-let deployReceipt = """
+let deployReceiptWithBlockInfo = """
 {
     "type": "DEPLOY",
     "transaction_hash": "0x333198614194ae5b5ef921e63898a592de5e9f4d7b6e04745093da88b429f2a",
@@ -118,7 +118,23 @@ let deployReceipt = """
     "contract_address": "0x789"
 }
 """
-let l1HandlerReceipt = """
+let deployReceipt = """
+{
+    "type": "DEPLOY",
+    "transaction_hash": "0x333198614194ae5b5ef921e63898a592de5e9f4d7b6e04745093da88b429f2a",
+    "actual_fee": {
+                    "amount": "0x244adfc7e22",
+                    "unit": "FRI"
+                },
+    "messages_sent": [],
+    "events": [],
+    "execution_status": "SUCCEEDED",
+    "finality_status": "ACCEPTED_ON_L2",
+    "execution_resources": {"steps": 999, "memory_holes" : 1, "range_check_builtin_applications": 21, "pedersen_builtin_applications": 37, "poseidon_builtin_applications": 451, "ec_op_builtin_applications": 123, "ecdsa_builtin_applications": 789, "bitwise_builtin_applications": 1, "keccak_builtin_applications": 1, "data_availability": {"l1_gas": 123, "l1_data_gas": 456}},
+    "contract_address": "0x789"
+}
+"""
+let l1HandlerReceiptWithBlockInfo = """
 {
     "type": "L1_HANDLER",
     "transaction_hash": "0x333198614194ae5b5ef921e63898a592de5e9f4d7b6e04745093da88b429f2a",
@@ -136,7 +152,7 @@ let l1HandlerReceipt = """
     "message_hash":"0x2137"
 }
 """
-let pendingL1HandlerReceipt = """
+let l1HandlerReceipt = """
 {
     "type": "L1_HANDLER",
     "transaction_hash": "0x333198614194ae5b5ef921e63898a592de5e9f4d7b6e04745093da88b429f2a",
@@ -156,27 +172,28 @@ let pendingL1HandlerReceipt = """
 final class TransactionReceiptTests: XCTestCase {
     func testTransactionReceiptWrapperDecoding() throws {
         let cases: [(String, StarknetTransactionType, Bool, any StarknetTransactionReceipt.Type)] = [
-            (invokeReceipt, .invoke, false, StarknetProcessedInvokeTransactionReceipt.self),
-            (declareReceipt, .declare, false, StarknetProcessedDeclareTransactionReceipt.self),
-            (deployAccountReceipt, .deployAccount, false, StarknetProcessedDeployAccountTransactionReceipt.self),
-            (l1HandlerReceipt, .l1Handler, false, StarknetProcessedL1HandlerTransactionReceipt.self),
-            (deployReceipt, .deploy, false, StarknetProcessedDeployTransactionReceipt.self),
-            (pendingInvokeReceipt, .invoke, true, StarknetPendingInvokeTransactionReceipt.self),
-            (pendingDeclareReceipt, .declare, true, StarknetPendingDeclareTransactionReceipt.self),
-            (pendingDeployAccountReceipt, .deployAccount, true, StarknetPendingDeployAccountTransactionReceipt.self),
-            (pendingL1HandlerReceipt, .l1Handler, true, StarknetPendingL1HandlerTransactionReceipt.self),
+            (invokeReceiptWithBlockInfo, .invoke, true, StarknetInvokeTransactionReceiptWithBlockInfo.self),
+            (declareReceiptWithBlockInfo, .declare, true, StarknetDeclareTransactionReceiptWithBlockInfo.self),
+            (deployAccountReceiptWithBlockInfo, .deployAccount, true, StarknetDeployAccountTransactionReceiptWithBlockInfo.self),
+            (l1HandlerReceiptWithBlockInfo, .l1Handler, true, StarknetL1HandlerTransactionReceiptWithBlockInfo.self),
+            (deployReceiptWithBlockInfo, .deploy, true, StarknetDeployTransactionReceiptWithBlockInfo.self),
+            (invokeReceipt, .invoke, false, StarknetInvokeTransactionReceipt.self),
+            (declareReceipt, .declare, false, StarknetDeclareTransactionReceipt.self),
+            (deployAccountReceipt, .deployAccount, false, StarknetDeployAccountTransactionReceipt.self),
+            (l1HandlerReceipt, .l1Handler, false, StarknetL1HandlerTransactionReceipt.self),
+            (deployReceipt, .deploy, false, StarknetDeployTransactionReceipt.self)
         ]
-        try cases.forEach { (string: String, txType: StarknetTransactionType, isPending: Bool, receiptType: StarknetTransactionReceipt.Type) in
+        try cases.forEach { (string: String, txType: StarknetTransactionType, hasBlockInfo: Bool, receiptType: StarknetTransactionReceipt.Type) in
             let data = string.data(using: .utf8)!
             let decoder = JSONDecoder()
 
             let receiptWrapper = try decoder.decode(TransactionReceiptWrapper.self, from: data)
             let receipt = receiptWrapper.transactionReceipt
 
-            if isPending {
-                XCTAssertTrue(receipt is (any StarknetPendingTransactionReceipt))
+            if hasBlockInfo {
+                XCTAssertTrue(receipt is (any StarknetTransactionReceiptWithBlockInfo))
             } else {
-                XCTAssertTrue(receipt is (any StarknetProcessedTransactionReceipt))
+                XCTAssertFalse(receipt is (any StarknetTransactionReceiptWithBlockInfo))
             }
 
             XCTAssertTrue(type(of: receipt) == receiptType)

--- a/Tests/StarknetTests/Data/TransactionReceiptTests.swift
+++ b/Tests/StarknetTests/Data/TransactionReceiptTests.swift
@@ -172,16 +172,16 @@ let l1HandlerReceipt = """
 final class TransactionReceiptTests: XCTestCase {
     func testTransactionReceiptWrapperDecoding() throws {
         let cases: [(String, StarknetTransactionType, Bool, any StarknetTransactionReceipt.Type)] = [
-            (invokeReceiptWithBlockInfo, .invoke, true, StarknetInvokeTransactionReceiptWithBlockInfo.self),
-            (declareReceiptWithBlockInfo, .declare, true, StarknetDeclareTransactionReceiptWithBlockInfo.self),
-            (deployAccountReceiptWithBlockInfo, .deployAccount, true, StarknetDeployAccountTransactionReceiptWithBlockInfo.self),
-            (l1HandlerReceiptWithBlockInfo, .l1Handler, true, StarknetL1HandlerTransactionReceiptWithBlockInfo.self),
-            (deployReceiptWithBlockInfo, .deploy, true, StarknetDeployTransactionReceiptWithBlockInfo.self),
+            (invokeReceiptWithBlockInfo, .invoke, true, StarknetInvokeTransactionReceipt.self),
+            (declareReceiptWithBlockInfo, .declare, true, StarknetDeclareTransactionReceipt.self),
+            (deployAccountReceiptWithBlockInfo, .deployAccount, true, StarknetDeployAccountTransactionReceipt.self),
+            (l1HandlerReceiptWithBlockInfo, .l1Handler, true, StarknetL1HandlerTransactionReceipt.self),
+            (deployReceiptWithBlockInfo, .deploy, true, StarknetDeployTransactionReceipt.self),
             (invokeReceipt, .invoke, false, StarknetInvokeTransactionReceipt.self),
             (declareReceipt, .declare, false, StarknetDeclareTransactionReceipt.self),
             (deployAccountReceipt, .deployAccount, false, StarknetDeployAccountTransactionReceipt.self),
             (l1HandlerReceipt, .l1Handler, false, StarknetL1HandlerTransactionReceipt.self),
-            (deployReceipt, .deploy, false, StarknetDeployTransactionReceipt.self)
+            (deployReceipt, .deploy, false, StarknetDeployTransactionReceipt.self),
         ]
         try cases.forEach { (string: String, txType: StarknetTransactionType, hasBlockInfo: Bool, receiptType: StarknetTransactionReceipt.Type) in
             let data = string.data(using: .utf8)!
@@ -191,9 +191,11 @@ final class TransactionReceiptTests: XCTestCase {
             let receipt = receiptWrapper.transactionReceipt
 
             if hasBlockInfo {
-                XCTAssertTrue(receipt is (any StarknetTransactionReceiptWithBlockInfo))
+                XCTAssertNotNil(receipt.blockNumber)
+                XCTAssertNotNil(receipt.blockHash)
             } else {
-                XCTAssertFalse(receipt is (any StarknetTransactionReceiptWithBlockInfo))
+                XCTAssertNil(receipt.blockNumber)
+                XCTAssertNil(receipt.blockHash)
             }
 
             XCTAssertTrue(type(of: receipt) == receiptType)


### PR DESCRIPTION
## Stack

-- Support RPC 0.7.0 (#162)
-- Add `execute` methods with custom fee multipliers (#163) 
-- Add transaction version enum (#164)
-- Refactor receipts (#165)

## Describe your changes

<!-- A brief description of the changes introduced in this PR -->
Adjust SDK following changes to tx receipts schemas in RPC 0.7.0.

Merge receipt structs with block info (a.k.a `processed`) and without it (a.k.a `pending`)
-  Remove `StarknetPendingTransactionReceipt`, `StarknetProcessedTransactionReceipt` protocols
- Add optional `blockHash` and `blockNumber` to `StarknetTransactionReceipt` protocol and all derived `Starknet[..]TransactionReceipt` structs

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [x] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->

- Removed `StarknetPendingTransactionReceipt`, `StarknetProcessedTransactionReceipt` protocols
- Renamed all `Starknet[..]TransactionReceipt` protocols to `Starknet[..]TransactionReceiptProtocol`
- Removed all `StarknetPending[..]TransactionReceipt` and `StarknetProcessed[..]TransactionReceipt` classes; Use `Starknet[..]TransactionReceipt` classes with optional `blockHash` and `blockNumber` instead

`[..]=[Invoke/DeployAccount/Declare/L1Handler/Deploy]`