### PR TITLE
Add `StarknetByteArray`; Support revision 1 `string` in `StarknetTypedData`

### DIFF
--- a/Sources/Starknet/Data/ByteArray.swift
+++ b/Sources/Starknet/Data/ByteArray.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+public struct StarknetByteArray: Equatable, Hashable, ExpressibleByStringLiteral {
+    let data: [Felt]
+    let pendingWord: Felt
+    let pendingWordLen: Int
+
+    public init?(data: [Felt], pendingWord: Felt, pendingWordLen: Int) {
+        self.data = data
+        self.pendingWord = pendingWord
+        self.pendingWordLen = pendingWordLen
+
+        guard self.data.allSatisfy({ $0.byteLength == 31 }),
+              self.pendingWordLen >= 0,
+              self.pendingWordLen < 31,
+              self.pendingWord.byteLength == self.pendingWordLen
+        else {
+            return nil
+        }
+    }
+
+    public init(fromString: String) {
+        let shortStrings = fromString.splitToShortStrings()
+        let encodedShortStrings = shortStrings.map { Felt.fromShortString($0)! }
+
+        if shortStrings.isEmpty || shortStrings.last!.count == 31 {
+            self.data = encodedShortStrings
+            self.pendingWord = .zero
+            self.pendingWordLen = 0
+        } else {
+            self.data = encodedShortStrings.dropLast()
+            self.pendingWord = encodedShortStrings.last!
+            self.pendingWordLen = shortStrings.last!.count
+        }
+    }
+}
+
+public extension StarknetByteArray {
+    typealias StringLiteralType = String
+
+    init(stringLiteral value: String) {
+        self.init(fromString: value)
+    }
+}
+
+public extension String {
+    func splitToShortStrings() -> [String] {
+        let maxLen = 31
+        return stride(from: 0, to: count, by: maxLen).map { index in
+            let startIndex = self.index(self.startIndex, offsetBy: index)
+            let endIndex = self.index(startIndex, offsetBy: maxLen, limitedBy: self.endIndex) ?? self.endIndex
+            return String(self[startIndex ..< endIndex])
+        }
+    }
+}
+
+private extension Felt {
+    var byteLength: Int {
+        (value.bitWidth + 7) / 8
+    }
+}

--- a/Tests/StarknetTests/Data/ByteArrayTests.swift
+++ b/Tests/StarknetTests/Data/ByteArrayTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+
+@testable import Starknet
+
+final class ByteArrayTests: XCTestCase {
+    static let cases: [(String, StarknetByteArray)] = [
+        ("hello", .init(data: [], pendingWord: "0x68656c6c6f", pendingWordLen: 5)!),
+        ("Long string, more than 31 characters.", .init(data: ["0x4c6f6e6720737472696e672c206d6f7265207468616e203331206368617261"], pendingWord: "0x63746572732e", pendingWordLen: 6)!),
+        ("ABCDEFGHIJKLMNOPQRSTUVWXYZ12345AAADEFGHIJKLMNOPQRSTUVWXYZ12345A", .init(data: ["0x4142434445464748494a4b4c4d4e4f505152535455565758595a3132333435", "0x4141414445464748494a4b4c4d4e4f505152535455565758595a3132333435"], pendingWord: "0x41", pendingWordLen: 1)!),
+        ("ABCDEFGHIJKLMNOPQRSTUVWXYZ12345", .init(data: ["0x4142434445464748494a4b4c4d4e4f505152535455565758595a3132333435"], pendingWord: .zero, pendingWordLen: 0)!),
+        ("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234", .init(data: [], pendingWord: "0x4142434445464748494a4b4c4d4e4f505152535455565758595a31323334", pendingWordLen: 30)!),
+        ("", .init(data: [], pendingWord: .zero, pendingWordLen: 0)!),
+    ]
+
+    func testByteArrayFromString() {
+        for (string, expected) in ByteArrayTests.cases {
+            print(string)
+            let actual = StarknetByteArray(fromString: string)
+            XCTAssertEqual(actual, expected)
+        }
+    }
+
+    func testExpressibleByStringLiteral() {
+        let byteArray: StarknetByteArray = "hello"
+        XCTAssertEqual(byteArray, StarknetByteArray(data: [], pendingWord: "0x68656c6c6f", pendingWordLen: 5))
+    }
+
+    func testInvalidByteArray() {
+        XCTAssertNil(StarknetByteArray(data: [], pendingWord: "0x68656c6c6f", pendingWordLen: 31)) // pendingWordLen too big
+        XCTAssertNil(StarknetByteArray(data: [], pendingWord: "0x68656c6c6f6", pendingWordLen: 4)) // pendingWordLen is not equal to the length of pendingWord
+        XCTAssertNil(StarknetByteArray(data: ["0x4142434445464748494a4b4c4d4e4f505152535455565758595a3132333435", "0x68656c6c6f"], pendingWord: .zero, pendingWordLen: 0)) // Not all data elements have length 31
+    }
+}


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

#### ByteArray
- Add `StarknetByteArray`
- Add `fromString` initializer
- Add initializer from string literal

#### TypedData


#### Other
- Add public `String.splitToShortStrings()` extension

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
