### PR TITLE
Bump docs runner version

### DIFF
--- a/.github/workflows/build_and_publish_docs.yml
+++ b/.github/workflows/build_and_publish_docs.yml
@@ -10,10 +10,15 @@ permissions:
 
 jobs:
   build-and-publish-docs:
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Setup Xcode 15.3
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: 15.3
 
       - name: Build docs
         run: |


### PR DESCRIPTION
## Describe your changes

- Bump docs runner: use `macos-14` instead of `macos-12`
- Add `Xcode 15.3` setup, to ensure `swift 5.10` usage

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #184 

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
