### PR TITLE
Use old approach to create accounts using `sncast`

### DIFF
--- a/Tests/StarknetTests/Devnet/DevnetClientTests.swift
+++ b/Tests/StarknetTests/Devnet/DevnetClientTests.swift
@@ -13,8 +13,7 @@ final class DevnetClientTests: XCTestCase {
         client.close()
     }
 
-    // TODO: (#130) re-enable once creating accounts is supported again
-    func disabledTestCreateDeployAccount() async throws {
+    func testCreateDeployAccount() async throws {
         let account = try await client.createDeployAccount(name: "Account1")
         try await client.assertTransactionSucceeded(transactionHash: account.transactionHash)
 
@@ -22,8 +21,7 @@ final class DevnetClientTests: XCTestCase {
         try await client.assertTransactionSucceeded(transactionHash: account2.transactionHash)
     }
 
-    // TODO: (#130) re-enable once creating accounts is supported again
-    func disabledTestCreateAndDeployAccount() async throws {
+    func testCreateAndDeployAccount() async throws {
         let account = try await client.createAccount()
         try await client.prefundAccount(address: account.details.address)
         let deployedAccount = try await client.deployAccount(name: account.name)

--- a/Tests/StarknetTests/Utils/DevnetClient/DevnetClient.swift
+++ b/Tests/StarknetTests/Utils/DevnetClient/DevnetClient.swift
@@ -291,18 +291,8 @@ func makeDevnetClient() -> DevnetClientProtocol {
             self.toolVersionsPath = newToolVersionsPath.path
             self.contractsPath = newContractsPath.path
 
-            // TODO: (#130) Use the old approach once we're able to update sncast
-            guard let accountsPath = Bundle.module.path(forResource: "starknet_open_zeppelin_accounts", ofType: "json") else {
-                throw DevnetClientError.missingResourceFile
-            }
-            let accountsResourcePath = URL(fileURLWithPath: accountsPath)
-            let newAccountsPath = URL(fileURLWithPath: "\(self.tmpPath)/starknet_open_zeppelin_accounts.json")
-            try fileManager.copyItem(at: accountsResourcePath, to: newAccountsPath)
-
-            let _ = try await deployAccount(name: "__default__")
-
-            // // Initialize new accounts file
-            // let _ = try await createDeployAccount(name: "__default__")
+            // Initialize new accounts file
+            let _ = try await createDeployAccount(name: "__default__")
         }
 
         public func close() {


### PR DESCRIPTION
## Describe your changes
- use `createDeployAccount` instead of using file with prepared accounts
- re-enable `testCreateDeployAccount`, `testCreateAndDeployAccount`

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #130 

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
