### PR TITLE
Fix types encoding in StarknetTypedData

### DIFF
--- a/Sources/Starknet/Data/TypedData/TypeDeclaration.swift
+++ b/Sources/Starknet/Data/TypedData/TypeDeclaration.swift
@@ -98,5 +98,17 @@ public extension StarknetTypedData {
                 self = try .standard(StandardType(from: decoder))
             }
         }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case let .standard(standardType):
+                try container.encode(standardType)
+            case let .enum(enumType):
+                try container.encode(enumType)
+            case let .merkletree(merkleTreeType):
+                try container.encode(merkleTreeType)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->
- Add `TypeDeclarationWrapper.encode()` method to properly encode `types` in `StarknetTypedData`
## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #196 

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
