### PR TITLE
Fix calculated overall fees in `FeeEstimateTests`

### DIFF
--- a/Tests/StarknetTests/Crypto/FeeEstimateTests.swift
+++ b/Tests/StarknetTests/Crypto/FeeEstimateTests.swift
@@ -31,7 +31,7 @@ final class FeeEstimateTests: XCTestCase {
                 (StarknetFeeEstimate(gasConsumed: 1, gasPrice: 2138, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 2148, feeUnit: .wei), 1.1, 2362),
                 (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 1000, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 10010, feeUnit: .wei), 1.0, 10010),
                 (StarknetFeeEstimate(gasConsumed: Felt(UInt64AsHex.max.value - 100)!, gasPrice: Felt(UInt128AsHex.max.value - 100)!, dataGasConsumed: 10, dataGasPrice: 1, overallFee: Felt.max, feeUnit: .wei), 1.1, Felt.max),
-                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 0, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 0, feeUnit: .wei), 1.5, 0),
+                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 0, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 10, feeUnit: .wei), 1.5, 15),
                 (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 2000, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 20010, feeUnit: .wei), 2, 40020),
             ]
 

--- a/Tests/StarknetTests/Crypto/FeeEstimateTests.swift
+++ b/Tests/StarknetTests/Crypto/FeeEstimateTests.swift
@@ -6,11 +6,11 @@ final class FeeEstimateTests: XCTestCase {
     func testEstimateFeeToResourceBounds() {
         let cases: [(StarknetFeeEstimate, Double, Double, StarknetResourceBounds)] =
             [
-                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 2138, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 21380, feeUnit: .wei), 1.1, 1.5, StarknetResourceBounds(maxAmount: 11, maxPricePerUnit: 3207)),
-                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 1000, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 10000, feeUnit: .wei), 1.0, 1.0, StarknetResourceBounds(maxAmount: 10, maxPricePerUnit: 1000)),
+                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 2138, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 21390, feeUnit: .wei), 1.1, 1.5, StarknetResourceBounds(maxAmount: 11, maxPricePerUnit: 3207)),
+                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 1000, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 10010, feeUnit: .wei), 1.0, 1.0, StarknetResourceBounds(maxAmount: 10, maxPricePerUnit: 1000)),
                 (StarknetFeeEstimate(gasConsumed: Felt(UInt64AsHex.max.value - 100)!, gasPrice: Felt(UInt128AsHex.max.value - 100)!, dataGasConsumed: Felt.max, dataGasPrice: 10, overallFee: Felt.max, feeUnit: .wei), 1.1, 1.5, StarknetResourceBounds(maxAmount: UInt64AsHex.max, maxPricePerUnit: UInt128AsHex.max)),
                 (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 0, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 10, feeUnit: .wei), 1.5, 1.5, StarknetResourceBounds(maxAmount: 0, maxPricePerUnit: 0)),
-                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 2000, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 20000, feeUnit: .wei), 2, 2, StarknetResourceBounds(maxAmount: 20, maxPricePerUnit: 4000)),
+                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 2000, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 20010, feeUnit: .wei), 2, 2, StarknetResourceBounds(maxAmount: 20, maxPricePerUnit: 4000)),
             ]
 
         cases.forEach {
@@ -28,11 +28,11 @@ final class FeeEstimateTests: XCTestCase {
     func testEstimateFeeToMaxFee() {
         let cases: [(StarknetFeeEstimate, Double, Felt)] =
             [
-                (StarknetFeeEstimate(gasConsumed: 1, gasPrice: 2138, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 2138, feeUnit: .wei), 1.1, 2351),
-                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 1000, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 10000, feeUnit: .wei), 1.0, 10000),
+                (StarknetFeeEstimate(gasConsumed: 1, gasPrice: 2138, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 2148, feeUnit: .wei), 1.1, 2362),
+                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 1000, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 10010, feeUnit: .wei), 1.0, 10010),
                 (StarknetFeeEstimate(gasConsumed: Felt(UInt64AsHex.max.value - 100)!, gasPrice: Felt(UInt128AsHex.max.value - 100)!, dataGasConsumed: 10, dataGasPrice: 1, overallFee: Felt.max, feeUnit: .wei), 1.1, Felt.max),
                 (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 0, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 0, feeUnit: .wei), 1.5, 0),
-                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 2000, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 20000, feeUnit: .wei), 2, 40000),
+                (StarknetFeeEstimate(gasConsumed: 10, gasPrice: 2000, dataGasConsumed: 10, dataGasPrice: 1, overallFee: 20010, feeUnit: .wei), 2, 40020),
             ]
 
         cases.forEach {


### PR DESCRIPTION
## Describe your changes

<!-- A brief description of the changes introduced in this PR -->

- Fix wrongly calculated `overallFee` passed while initializing `StarknetFeeEstimate` test cases

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
