### PR TITLE
Fix typed data serialization

### DIFF
--- a/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
+++ b/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
@@ -607,13 +607,10 @@ extension StarknetTypedData {
     func unwrapBool(from element: Element) throws -> Felt {
         switch element {
         case let .decimal(decimal):
-            if decimal == 0 {
-                return .zero
-            } else if decimal == 1 {
-                return .one
-            } else {
+            guard decimal == 0 || decimal == 1 else {
                 throw StarknetTypedDataError.invalidBool(element)
             }
+            return decimal == 0 ? .zero : .one
         case let .felt(felt):
             guard felt == .zero || felt == .one else {
                 throw StarknetTypedDataError.invalidBool(element)

--- a/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
+++ b/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
@@ -406,13 +406,6 @@ public extension StarknetTypedData {
             }
         }
 
-        enum CodingKeys: String, CodingKey {
-            case name
-            case version
-            case chainId
-            case revision
-        }
-
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.name = try container.decode(Element.self, forKey: .name)

--- a/Sources/Starknet/Data/TypedData/TypeDeclaration.swift
+++ b/Sources/Starknet/Data/TypedData/TypeDeclaration.swift
@@ -27,6 +27,7 @@ public extension StarknetTypedData {
         fileprivate enum CodingKeys: String, CodingKey {
             case name
             case contains
+            case type
         }
     }
 
@@ -43,6 +44,7 @@ public extension StarknetTypedData {
         fileprivate enum CodingKeys: String, CodingKey {
             case name
             case contains
+            case type
         }
     }
 

--- a/Tests/StarknetTests/Data/TypedDataTests.swift
+++ b/Tests/StarknetTests/Data/TypedDataTests.swift
@@ -456,4 +456,22 @@ final class TypedDataTests: XCTestCase {
             XCTAssertEqual(hash, expectedResult)
         }
     }
+    
+    func testEncodingTimestamp() throws {
+        let tdJsonStr = try loadTypedDataJsonStringFromFile(name: "typed_data_rev_1_timestamp_example")
+        guard let tdEncodedContents = tdJsonStr.data(using: .utf8) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Failed to load typed data"))
+        }
+
+        do {
+            let td = try JSONDecoder().decode(StarknetTypedData.self, from: tdEncodedContents)
+            let tdEncoded = try JSONEncoder().encode(td)
+            let originalJson = try JSONSerialization.jsonObject(with: tdEncodedContents, options: []) as? [String: Any]
+            let encodedJson = try JSONSerialization.jsonObject(with: tdEncoded, options: []) as? [String: Any]
+            
+            XCTAssertEqual(originalJson as NSDictionary?, encodedJson as NSDictionary?)
+        } catch let e {
+            throw e
+        }
+    }
 }

--- a/Tests/StarknetTests/Data/TypedDataTests.swift
+++ b/Tests/StarknetTests/Data/TypedDataTests.swift
@@ -456,7 +456,7 @@ final class TypedDataTests: XCTestCase {
             XCTAssertEqual(hash, expectedResult)
         }
     }
-    
+
     func testEncodingTimestamp() throws {
         let tdJsonStr = try loadTypedDataJsonStringFromFile(name: "typed_data_rev_1_timestamp_example")
         guard let tdEncodedContents = tdJsonStr.data(using: .utf8) else {
@@ -468,7 +468,7 @@ final class TypedDataTests: XCTestCase {
             let tdEncoded = try JSONEncoder().encode(td)
             let originalJson = try JSONSerialization.jsonObject(with: tdEncodedContents, options: []) as? [String: Any]
             let encodedJson = try JSONSerialization.jsonObject(with: tdEncoded, options: []) as? [String: Any]
-            
+
             XCTAssertEqual(originalJson as NSDictionary?, encodedJson as NSDictionary?)
         } catch let e {
             throw e

--- a/Tests/StarknetTests/Resources/TypedData/typed_data_rev_1_timestamp_example.json
+++ b/Tests/StarknetTests/Resources/TypedData/typed_data_rev_1_timestamp_example.json
@@ -1,0 +1,69 @@
+{
+  "types": {
+    "StarknetDomain": [
+      {
+        "name": "name",
+        "type": "shortstring"
+      },
+      {
+        "name": "version",
+        "type": "shortstring"
+      },
+      {
+        "name": "chainId",
+        "type": "shortstring"
+      },
+      {
+        "name": "revision",
+        "type": "shortstring"
+      }
+    ],
+    "Allowed Method": [
+      {
+        "name": "Contract Address",
+        "type": "ContractAddress"
+      },
+      {
+        "name": "selector",
+        "type": "selector"
+      }
+    ],
+    "Session": [
+      {
+        "name": "Expires At",
+        "type": "timestamp"
+      },
+      {
+        "name": "Allowed Methods",
+        "type": "merkletree",
+        "contains": "Allowed Method"
+      },
+      {
+        "name": "Metadata",
+        "type": "string"
+      },
+      {
+        "name": "Session Key",
+        "type": "felt"
+      }
+    ]
+  },
+  "primaryType": "Session",
+  "domain": {
+    "name": "SessionAccount.session",
+    "version": "0x31",
+    "chainId": "0x534e5f5345504f4c4941",
+    "revision": "1"
+  },
+  "message": {
+    "Expires At": 1720704208,
+    "Allowed Methods": [
+      {
+        "Contract Address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "selector": "transfer"
+      }
+    ],
+    "Metadata": "{\"projectID\":\"test-dapp\",\"txFees\":[{\"tokenAddress\":\"0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7\",\"maxAmount\":\"100000000000000000\"}]}",
+    "Session Key": "0x3f94fb0d79cba8507a8775dc4cd4328f91ba33d1a32cb54c8c28eef0e258fa3"
+  }
+}

--- a/Tests/StarknetTests/Utils/StarknetTypedData.swift
+++ b/Tests/StarknetTests/Utils/StarknetTypedData.swift
@@ -18,3 +18,13 @@ func loadTypedDataFromFile(name: String) throws -> StarknetTypedData {
 
     return try JSONDecoder().decode(StarknetTypedData.self, from: contentsData)
 }
+
+
+func loadTypedDataJsonStringFromFile(name: String) throws -> String {
+    guard let url = Bundle.module.url(forResource: name, withExtension: "json"),
+          let contents = try? String(contentsOf: url)
+    else {
+        throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Failed to load typed data from file \(name)"))
+    }
+    return contents
+}

--- a/Tests/StarknetTests/Utils/StarknetTypedData.swift
+++ b/Tests/StarknetTests/Utils/StarknetTypedData.swift
@@ -19,7 +19,6 @@ func loadTypedDataFromFile(name: String) throws -> StarknetTypedData {
     return try JSONDecoder().decode(StarknetTypedData.self, from: contentsData)
 }
 
-
 func loadTypedDataJsonStringFromFile(name: String) throws -> String {
     guard let url = Bundle.module.url(forResource: name, withExtension: "json"),
           let contents = try? String(contentsOf: url)


### PR DESCRIPTION
## Describe your changes

Fix encoding of `u128`, `i128` and `timestamp`

**Before**: When typed data was decoded to `StarknetTypedData` and then encoded again to JSON,  `u128`, `i128` and `timestamp` were encoded as hex values
**Now**: They are encoded in line with [SNIP-12](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-12.md)

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #204, #205, #206 

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
