### PR TITLE
Fix encoding `version`  in typed data `Domain`

### DIFF
--- a/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
+++ b/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
@@ -737,6 +737,29 @@ extension StarknetTypedData {
     }
 }
 
+extension StarknetTypedData.Element: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case let .string(s):
+            s
+        case let .decimal(n):
+            String(n)
+        case let .signedDecimal(n):
+            String(n)
+        case let .felt(f):
+            f.toHex()
+        case let .signedFelt(f):
+            f.toHex()
+        case let .bool(b):
+            String(b)
+        case .object:
+            String(describing: self)
+        case .array:
+            String(describing: self)
+        }
+    }
+}
+
 private extension String {
     func strippingPointer() -> String {
         if self.isArray() {

--- a/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
+++ b/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
@@ -424,10 +424,7 @@ public extension StarknetTypedData {
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(name, forKey: .name)
-
-            let versionString = try version.toString()
-            try container.encode(versionString, forKey: .version)
-
+            try container.encode(String(describing: version), forKey: .version)
             try container.encode(chainId, forKey: .chainId)
             try container.encode(revision, forKey: .revision)
         }

--- a/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
+++ b/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
@@ -518,21 +518,6 @@ public extension StarknetTypedData {
     }
 }
 
-extension StarknetTypedData.Element {
-    func toString() throws -> String {
-        switch self {
-        case let .string(s): return s
-        case let .decimal(n): return String(n)
-        case let .signedDecimal(n): return String(n)
-        case let .felt(f): return f.toHex()
-        case let .signedFelt(f): return f.toHex()
-        case let .bool(b): return String(b)
-        default:
-            throw StarknetTypedDataError.encodingError
-        }
-    }
-}
-
 extension StarknetTypedData {
     struct Context: Equatable {
         let parent: String

--- a/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
+++ b/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
@@ -722,12 +722,22 @@ extension StarknetTypedData {
 extension StarknetTypedData.Element: CustomStringConvertible {
     public var description: String {
         switch self {
-        case .string(_), .decimal(_), .signedDecimal(_), .bool(_), .object(_), .array:
-            String(describing: self)
+        case let .string(s):
+            s
+        case let .decimal(n):
+            String(n)
+        case let .signedDecimal(n):
+            String(n)
         case let .felt(f):
             f.toHex()
         case let .signedFelt(f):
             f.toHex()
+        case let .bool(b):
+            String(b)
+        case .object:
+            String(describing: self)
+        case .array:
+            String(describing: self)
         }
     }
 }

--- a/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
+++ b/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
@@ -740,22 +740,12 @@ extension StarknetTypedData {
 extension StarknetTypedData.Element: CustomStringConvertible {
     public var description: String {
         switch self {
-        case let .string(s):
-            String(describing: self)
-        case let .decimal(n):
-            String(describing: self)
-        case let .signedDecimal(n):
+        case .string(_), .decimal(_), .signedDecimal(_), .bool(_), .object(_), .array:
             String(describing: self)
         case let .felt(f):
             f.toHex()
         case let .signedFelt(f):
             f.toHex()
-        case let .bool(b):
-            String(describing: self)
-        case .object:
-            String(describing: self)
-        case .array:
-            String(describing: self)
         }
     }
 }

--- a/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
+++ b/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
@@ -741,17 +741,17 @@ extension StarknetTypedData.Element: CustomStringConvertible {
     public var description: String {
         switch self {
         case let .string(s):
-            s
+            String(describing: self)
         case let .decimal(n):
-            String(n)
+            String(describing: self)
         case let .signedDecimal(n):
-            String(n)
+            String(describing: self)
         case let .felt(f):
             f.toHex()
         case let .signedFelt(f):
             f.toHex()
         case let .bool(b):
-            String(b)
+            String(describing: self)
         case .object:
             String(describing: self)
         case .array:

--- a/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
+++ b/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
@@ -478,28 +478,6 @@ public extension StarknetTypedData {
         }
 
         public func encode(to encoder: Encoder) throws {
-            if let currentKey = encoder.codingPath.last?.stringValue,
-               currentKey == "version"
-            {
-                print("XXX", currentKey)
-                switch self {
-                case let .string(s):
-                    print("aa")
-                    try s.encode(to: encoder)
-                case let .felt(felt), let .signedFelt(felt):
-                    let hexString: String = "\(felt.toShortString())"
-                    print("hex string", type(of: hexString))
-                    var container = encoder.singleValueContainer()
-                    try container.encode(hexString)
-                default:
-                    print("dd")
-
-                    let s = "\(self)"
-                    try s.encode(to: encoder)
-                }
-                return
-            }
-
             switch self {
             case let .string(string):
                 try string.encode(to: encoder)

--- a/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
+++ b/Sources/Starknet/Data/TypedData/StarknetTypedData.swift
@@ -395,7 +395,7 @@ public struct StarknetTypedData: Codable, Equatable, Hashable {
 public extension StarknetTypedData {
     struct Domain: Codable, Equatable, Hashable {
         public let name: Element
-        public let version: Element
+        public let version: String
         public let chainId: Element
         public let revision: Revision
 
@@ -409,7 +409,7 @@ public extension StarknetTypedData {
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.name = try container.decode(Element.self, forKey: .name)
-            self.version = try container.decode(Element.self, forKey: .version)
+            self.version = try container.decode(String.self, forKey: .version)
             self.chainId = try container.decode(Element.self, forKey: .chainId)
             self.revision = try container.decodeIfPresent(Revision.self, forKey: .revision) ?? .v0
         }
@@ -478,6 +478,28 @@ public extension StarknetTypedData {
         }
 
         public func encode(to encoder: Encoder) throws {
+            if let currentKey = encoder.codingPath.last?.stringValue,
+               currentKey == "version"
+            {
+                print("XXX", currentKey)
+                switch self {
+                case let .string(s):
+                    print("aa")
+                    try s.encode(to: encoder)
+                case let .felt(felt), let .signedFelt(felt):
+                    let hexString: String = "\(felt.toShortString())"
+                    print("hex string", type(of: hexString))
+                    var container = encoder.singleValueContainer()
+                    try container.encode(hexString)
+                default:
+                    print("dd")
+
+                    let s = "\(self)"
+                    try s.encode(to: encoder)
+                }
+                return
+            }
+
             switch self {
             case let .string(string):
                 try string.encode(to: encoder)

--- a/Tests/StarknetTests/Data/TypedDataTests.swift
+++ b/Tests/StarknetTests/Data/TypedDataTests.swift
@@ -47,14 +47,14 @@ final class TypedDataTests: XCTestCase {
     static let exampleDomainV0 = """
     {
         "name": "DomainV0",
-        "version": 1,
+        "version": "1",
         "chainId": 2137,
     }
     """
     static let exampleDomainV1 = """
     {
         "name": "DomainV1",
-        "version": 2,
+        "version": "2",
         "chainId": "2137",
         "revision": 1
     }


### PR DESCRIPTION
## Describe your changes

`version` in `Domain` is now encoded as string, instead of number

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes #227 

## Breaking changes

- [ ] This issue contains breaking changes
<!-- List all breaking changes introduced by this issue -->
