### PR TITLE
Remove usage of `UInt128` from `prefundAccount`

### DIFF
--- a/Tests/StarknetTests/Accounts/AccountTest.swift
+++ b/Tests/StarknetTests/Accounts/AccountTest.swift
@@ -2,7 +2,6 @@ import XCTest
 
 @testable import Starknet
 
-@available(macOS 15.0, *)
 final class AccountTests: XCTestCase {
     static var devnetClient: DevnetClientProtocol!
 

--- a/Tests/StarknetTests/Data/ExecutionTests.swift
+++ b/Tests/StarknetTests/Data/ExecutionTests.swift
@@ -2,7 +2,6 @@ import XCTest
 
 @testable import Starknet
 
-@available(macOS 15.0, *)
 final class ExecutionTests: XCTestCase {
     static var devnetClient: DevnetClientProtocol!
 

--- a/Tests/StarknetTests/Devnet/DevnetClientTests.swift
+++ b/Tests/StarknetTests/Devnet/DevnetClientTests.swift
@@ -1,7 +1,6 @@
 @testable import Starknet
 import XCTest
 
-@available(macOS 15.0, *)
 final class DevnetClientTests: XCTestCase {
     var client: DevnetClientProtocol!
 

--- a/Tests/StarknetTests/Providers/ProviderTests.swift
+++ b/Tests/StarknetTests/Providers/ProviderTests.swift
@@ -2,7 +2,6 @@ import XCTest
 
 @testable import Starknet
 
-@available(macOS 15.0, *)
 final class ProviderTests: XCTestCase {
     static var devnetClient: DevnetClientProtocol!
 

--- a/Tests/StarknetTests/Utils/DevnetClient/DevnetClient.swift
+++ b/Tests/StarknetTests/Utils/DevnetClient/DevnetClient.swift
@@ -34,8 +34,7 @@ protocol DevnetClientProtocol {
 }
 
 extension DevnetClientProtocol {
-    // 0x84595161401484A000000 = 10_000_000_000_000_000_000_000_000
-    func prefundAccount(address: Felt, amount: BigUInt = BigUInt(stringLiteral: "10000000000000000000000000"), unit: StarknetPriceUnit = .fri) async throws {
+    func prefundAccount(address: Felt, amount: BigUInt = BigUInt(10).power(23), unit: StarknetPriceUnit = .fri) async throws {
         try await prefundAccount(address: address, amount: amount, unit: unit)
     }
 

--- a/Tests/StarknetTests/Utils/DevnetClient/DevnetClient.swift
+++ b/Tests/StarknetTests/Utils/DevnetClient/DevnetClient.swift
@@ -18,7 +18,7 @@ protocol DevnetClientProtocol {
 
     func isRunning() -> Bool
 
-    func prefundAccount(address: Felt, amount: UInt128AsHex, unit: StarknetPriceUnit) async throws
+    func prefundAccount(address: Felt, amount: BigUInt, unit: StarknetPriceUnit) async throws
     func createDeployAccount(name: String, classHash: Felt, salt: Felt?) async throws -> DeployAccountResult
     func createAccount(name: String, classHash: Felt, salt: Felt?, type: String) async throws -> CreateAccountResult
     func deployAccount(name: String, classHash: Felt, prefund: Bool) async throws -> DeployAccountResult
@@ -35,7 +35,7 @@ protocol DevnetClientProtocol {
 
 extension DevnetClientProtocol {
     // 0x84595161401484A000000 = 10_000_000_000_000_000_000_000_000
-    func prefundAccount(address: Felt, amount: UInt128AsHex = UInt128AsHex(fromHex: "0x84595161401484A000000")!, unit: StarknetPriceUnit = .fri) async throws {
+    func prefundAccount(address: Felt, amount: BigUInt = BigUInt(stringLiteral: "10000000000000000000000000"), unit: StarknetPriceUnit = .fri) async throws {
         try await prefundAccount(address: address, amount: amount, unit: unit)
     }
 
@@ -294,7 +294,7 @@ func makeDevnetClient() -> DevnetClientProtocol {
             self.devnetProcess = nil
         }
 
-        public func prefundAccount(address: Felt, amount: UInt128AsHex, unit: StarknetPriceUnit) async throws {
+        public func prefundAccount(address: Felt, amount: BigUInt, unit: StarknetPriceUnit) async throws {
             try guardDevnetIsRunning()
 
             let url = URL(string: mintUrl)!

--- a/Tests/StarknetTests/Utils/DevnetClient/DevnetClient.swift
+++ b/Tests/StarknetTests/Utils/DevnetClient/DevnetClient.swift
@@ -305,7 +305,7 @@ func makeDevnetClient() -> DevnetClientProtocol {
 
             // TODO(#209): Once we can use UInt128, we can simply set
             // body as `request.httpBody = try JSONEncoder().encode(payload)`
-            // Below adjustment is needed to remove quotes from the amount field
+            // Following adjustment is needed to remove quotes from the amount field
             // in the JSON body, because ATM we can't use UInt128 in the payload.
 
             let data = try JSONEncoder().encode(payload)

--- a/Tests/StarknetTests/Utils/DevnetClient/DevnetClient.swift
+++ b/Tests/StarknetTests/Utils/DevnetClient/DevnetClient.swift
@@ -34,6 +34,7 @@ protocol DevnetClientProtocol {
 }
 
 extension DevnetClientProtocol {
+    // 0x84595161401484A000000 = 10_000_000_000_000_000_000_000_000
     func prefundAccount(address: Felt, amount: UInt128AsHex = UInt128AsHex(fromHex: "0x84595161401484A000000")!, unit: StarknetPriceUnit = .fri) async throws {
         try await prefundAccount(address: address, amount: amount, unit: unit)
     }

--- a/Tests/StarknetTests/Utils/DevnetClient/DevnetClientModels.swift
+++ b/Tests/StarknetTests/Utils/DevnetClient/DevnetClientModels.swift
@@ -75,11 +75,26 @@ struct InvokeContractResult {
     let transactionHash: Felt
 }
 
-@available(macOS 15.0, *)
+// TODO(#209): Once we can use UInt128, we should change type of `amount`` to UInt128
+// and remove coding keys and `encode` method (they won't be needed).
+
 struct PrefundPayload: Codable {
     let address: Felt
-    let amount: UInt128
+    let amount: UInt128AsHex
     let unit: StarknetPriceUnit
+
+    enum CodingKeys: String, CodingKey {
+        case address
+        case amount
+        case unit
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(address, forKey: .address)
+        try container.encode(amount.value.description, forKey: .amount)
+        try container.encode(unit, forKey: .unit)
+    }
 }
 
 // Simplified receipt that is intended to support any JSON-RPC version starting 0.3,

--- a/Tests/StarknetTests/Utils/DevnetClient/DevnetClientModels.swift
+++ b/Tests/StarknetTests/Utils/DevnetClient/DevnetClientModels.swift
@@ -75,7 +75,7 @@ struct InvokeContractResult {
     let transactionHash: Felt
 }
 
-// TODO(#209): Once we can use UInt128, we should change type of `amount`` to UInt128
+// TODO(#209): Once we can use UInt128, we should change type of `amount` to UInt128
 // and remove coding keys and `encode` method (they won't be needed).
 
 struct PrefundPayload: Codable {

--- a/Tests/StarknetTests/Utils/DevnetClient/DevnetClientModels.swift
+++ b/Tests/StarknetTests/Utils/DevnetClient/DevnetClientModels.swift
@@ -80,7 +80,7 @@ struct InvokeContractResult {
 
 struct PrefundPayload: Codable {
     let address: Felt
-    let amount: UInt128AsHex
+    let amount: BigUInt
     let unit: StarknetPriceUnit
 
     enum CodingKeys: String, CodingKey {
@@ -92,7 +92,7 @@ struct PrefundPayload: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(address, forKey: .address)
-        try container.encode(amount.value.description, forKey: .amount)
+        try container.encode(amount.description, forKey: .amount)
         try container.encode(unit, forKey: .unit)
     }
 }


### PR DESCRIPTION
## Describe your changes

This PR removes usage of `UInt128` which results in removal macOS 15.0 requirement in our tests

## Linked issues

<!-- Reference any GitHub issues resolved by this PR starting every line with `Closes` -->

Closes

## Breaking changes

- [ ] This issue contains breaking changes

<!-- List all breaking changes introduced by this issue -->
