### PR TITLE
Update dependencies for Swift 6.2 compatibility

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "72a3e55c1889ff1d1952dd33089cbab12dbf307b5055f607a8ff4e8f62350834",
   "pins" : [
     {
       "identity" : "bigint",
@@ -14,10 +15,10 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
       "state" : {
-        "revision" : "039f56c5d7960f277087a0be51f5eb04ed0ec073",
-        "version" : "1.5.1"
+        "revision" : "e45a26384239e028ec87fbcc788f513b67e10d8f",
+        "version" : "1.9.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/attaswift/BigInt.git", from: "5.3.0"),
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", exact: "1.5.1"),
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.9.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Starknet/Data/ContractAddressCalculator.swift
+++ b/Sources/Starknet/Data/ContractAddressCalculator.swift
@@ -22,7 +22,7 @@ public class StarknetContractAddressCalculator {
         let hex = address.toHex().dropFirst(2)
         let stringAddress = String(String(hex.reversed()).padding(toLength: 64, withPad: "0", startingAt: 0).reversed())
         var chars = Array(stringAddress)
-        let hashed = keccak(on: BigUInt(hex, radix: 16)!.serialize().bytes)
+        let hashed = keccak(on: BigUInt(hex, radix: 16)!.serialize().byteArray)
 
         for i in 0 ... chars.count - 1 {
             let bit = BigUInt(2).power(256 - 4 * i - 1)


### PR DESCRIPTION
- Update CryptoSwift from 1.5.1 to 1.9.0

The CryptoSwift 1.9.0 update includes the bytes -> byteArray property rename to avoid conflicts with Swift 6.2's new bytes: RawSpan property ([SE-0456](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://forums.swift.org/t/se-0456-add-span-providing-properties-to-standard-library-types/77233&ved=2ahUKEwj9l5OKldaOAxXLBdsEHWtvJv4QFnoECBQQAQ&usg=AOvVaw3LNKb5YSa_XAScxJ2BuGwP)).