### PR TITLE
feat: add dynamic linking option to fix SwiftUI preview issues

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,12 @@ let package = Package(
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "Starknet",
+            type: .static,
+            targets: ["Starknet"]
+        ),
+        .library(
+            name: "StarknetDynamic",
+            type: .dynamic,
             targets: ["Starknet"]
         ),
     ],

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ dependencies: [
 Then add `starknet.swift` to the dependencies array of every target you want to use the package in.
 ```
 
+### Choosing the Right Product
+
+The package offers two library products:
+
+- `Starknet` – statically linked variant. Prefer this when you control the final app binary and want to avoid extra runtime bundles.
+- `StarknetDynamic` – dynamically linked variant. Use this for SwiftUI previews or any build pipeline that performs aggressive dead-symbol stripping.
+
+If you rely on SwiftUI previews or hit missing native symbol errors (`_generate_k`, `_Sign`, etc.), switch the dependency in your target to `StarknetDynamic`.
+
 ## Documentation
 You can find the documentation of the project [here](https://docs.swmansion.com/starknet.swift/documentation/starknet/).
 


### PR DESCRIPTION
- Add StarknetDynamic product as dynamic library variant
- Keep Starknet as static library for existing consumers
- Update README with guidance on choosing the right product
- Resolves SwiftUI preview link failures caused by dead symbol stripping
- Fixes missing native crypto symbols (_generate_k, _Sign, etc.)

Fixes #256